### PR TITLE
Correcting some misspelled words and removing unnecessary else statements.

### DIFF
--- a/cmd/skylark/skylark.go
+++ b/cmd/skylark/skylark.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/skylark"
 	"github.com/google/skylark/resolve"
 	"github.com/google/skylark/syntax"
+	"io"
 )
 
 // flags
@@ -93,7 +94,7 @@ func repl() {
 	sc := bufio.NewScanner(os.Stdin)
 outer:
 	for {
-		fmt.Fprintf(os.Stderr, ">>> ")
+		io.WriteString(os.Stderr, ">>> ")
 		if !sc.Scan() {
 			break
 		}
@@ -118,7 +119,7 @@ outer:
 		var buf bytes.Buffer
 		fmt.Fprintln(&buf, line)
 		for {
-			fmt.Fprintf(os.Stderr, "... ")
+			io.WriteString(os.Stderr, "... ")
 			if !sc.Scan() {
 				break outer
 			}

--- a/eval.go
+++ b/eval.go
@@ -836,11 +836,11 @@ func eval(fr *Frame, e syntax.Expr) (Value, error) {
 		// comparisons
 		switch e.Op {
 		case syntax.EQL, syntax.NEQ, syntax.GT, syntax.LT, syntax.LE, syntax.GE:
-			if ok, err := Compare(e.Op, x, y); err != nil {
+			ok, err := Compare(e.Op, x, y)
+			if err != nil {
 				return nil, fr.errorf(e.OpPos, "%s", err)
-			} else {
-				return Bool(ok), nil
 			}
+			return Bool(ok), nil
 		}
 
 		// binary operators

--- a/int.go
+++ b/int.go
@@ -198,9 +198,9 @@ func ConvertToInt(x Value) (Int, error) {
 			return zero, fmt.Errorf("cannot convert float infinity to integer")
 		} else if math.IsNaN(f) {
 			return zero, fmt.Errorf("cannot convert float NaN to integer")
-		} else {
-			return finiteFloatToInt(x), nil
 		}
+		return finiteFloatToInt(x), nil
+
 	}
 	return zero, fmt.Errorf("cannot convert %s to int", x.Type())
 }

--- a/library.go
+++ b/library.go
@@ -954,13 +954,12 @@ func (s *sortSlice) Less(i, j int) bool {
 		}
 		cmp, ok := res.(Int)
 		return ok && cmp.Sign() < 0
-	} else {
-		ok, err := Compare(syntax.LT, x, y)
-		if err != nil {
-			s.err = err
-		}
-		return ok
 	}
+	ok, err := Compare(syntax.LT, x, y)
+	if err != nil {
+		s.err = err
+	}
+	return ok
 }
 func (s *sortSlice) Swap(i, j int) {
 	s.elems[i], s.elems[j] = s.elems[j], s.elems[i]
@@ -1063,9 +1062,8 @@ func dict_get(fnname string, recv Value, args Tuple, kwargs []Tuple) (Value, err
 		return v, nil
 	} else if dflt != nil {
 		return dflt, nil
-	} else {
-		return None, nil
 	}
+	return None, nil
 }
 
 // https://docs.python.org/2/library/stdtypes.html#dict.clear
@@ -1110,9 +1108,8 @@ func dict_pop(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value, er
 		return v, nil
 	} else if d != nil {
 		return d, nil
-	} else {
-		return nil, fmt.Errorf("pop: missing key")
 	}
+	return nil, fmt.Errorf("pop: missing key")
 }
 
 // https://docs.python.org/2/library/stdtypes.html#dict.popitem
@@ -1617,11 +1614,11 @@ func string_join(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value,
 		if i > 0 {
 			buf.WriteString(recv)
 		}
-		if s, ok := AsString(x); !ok {
+		s, ok := AsString(x)
+		if !ok {
 			return nil, fmt.Errorf("in list, want string, got %s", x.Type())
-		} else {
-			buf.WriteString(s)
 		}
+		buf.WriteString(s)
 	}
 	return String(buf.String()), nil
 }

--- a/library.go
+++ b/library.go
@@ -1786,7 +1786,7 @@ func string_split(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value
 
 	} else if sep, ok := AsString(sep_); ok {
 		if sep == "" {
-			return nil, fmt.Errorf("split: empty seperator")
+			return nil, fmt.Errorf("split: empty separator")
 		}
 		// usual case: split on non-empty separator
 		if maxsplit == 0 {
@@ -1804,7 +1804,7 @@ func string_split(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value
 		}
 
 	} else {
-		return nil, fmt.Errorf("split: got %s for seperator, want string", sep_.Type())
+		return nil, fmt.Errorf("split: got %s for separator, want string", sep_.Type())
 	}
 
 	list := make([]Value, len(res))

--- a/skylarkstruct/struct.go
+++ b/skylarkstruct/struct.go
@@ -12,7 +12,7 @@ package skylarkstruct
 // TODO(adonovan): the deprecated struct methods "to_json" and
 // "to_proto" do not appear in AttrNames, and hence dir(struct), since
 // that would force the majority to have to ignore them, but they may
-// nontheless be called if the struct does not have fields of these
+// nonetheless be called if the struct does not have fields of these
 // names. Ideally these will go away soon. See b/36412967.
 
 import (

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -97,9 +97,8 @@ func (p *parser) parseStmt(stmts []Stmt) []Stmt {
 		return append(stmts, p.parseIfStmt())
 	} else if p.tok == FOR {
 		return append(stmts, p.parseForStmt())
-	} else {
-		return p.parseSimpleStmt(stmts)
 	}
+	return p.parseSimpleStmt(stmts)
 }
 
 func (p *parser) parseDefStmt() Stmt {


### PR DESCRIPTION
- Fix three misspelled words in the files.
- Remove some unnecessary else statements. 
- Substitute some `fmt.Fprintf` to `Fprint` when there is no need to use formatted strings (they are less expensive).