### PR TITLE
resolve: clarify is{PredeclaredGlobal,Builtin} parameters

### DIFF
--- a/cmd/skylark/skylark.go
+++ b/cmd/skylark/skylark.go
@@ -187,9 +187,7 @@ func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.S
 	}
 
 	// resolve
-	isPredeclaredGlobal := func(name string) bool { return globals[name] != nil }
-	isBuiltin := func(name string) bool { return skylark.Universe[name] != nil }
-	if err := resolve.File(f, isPredeclaredGlobal, isBuiltin); err != nil {
+	if err := resolve.File(f, globals.Has, skylark.Universe.Has); err != nil {
 		return err
 
 	}

--- a/eval.go
+++ b/eval.go
@@ -96,7 +96,8 @@ func (d StringDict) Freeze() {
 	}
 }
 
-func (d StringDict) has(name string) bool { _, ok := d[name]; return ok }
+// Has reports whether the dictionary contains the specified key.
+func (d StringDict) Has(key string) bool { _, ok := d[key]; return ok }
 
 // A Frame holds the execution state of a single Skylark function call
 // or module toplevel.
@@ -157,7 +158,7 @@ func (fr *Frame) lookup(id *syntax.Ident) (Value, error) {
 				return v.fn(fr.thread, v, nil, nil)
 			}
 		}
-	case resolve.Builtin:
+	case resolve.Universal:
 		return Universe[id.Name], nil
 	}
 	return nil, fr.errorf(id.NamePos, "%s variable %s referenced before assignment",
@@ -259,7 +260,7 @@ func Exec(opts ExecOptions) error {
 	}
 
 	globals := opts.Globals
-	if err := resolve.File(f, globals.has, Universe.has); err != nil {
+	if err := resolve.File(f, globals.Has, Universe.Has); err != nil {
 		return err
 	}
 
@@ -315,7 +316,7 @@ func Eval(thread *Thread, filename string, src interface{}, globals StringDict) 
 		return nil, err
 	}
 
-	locals, err := resolve.Expr(expr, globals.has, Universe.has)
+	locals, err := resolve.Expr(expr, globals.Has, Universe.Has)
 	if err != nil {
 		return nil, err
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -444,9 +444,8 @@ func TestRepeatedExec(t *testing.T) {
 	}
 
 	isPredeclaredGlobal := func(name string) bool { return name == "x" } // x, but not y
-	isBuiltin := func(name string) bool { return skylark.Universe[name] != nil }
 
-	if err := resolve.File(f, isPredeclaredGlobal, isBuiltin); err != nil {
+	if err := resolve.File(f, isPredeclaredGlobal, skylark.Universe.Has); err != nil {
 		t.Fatal(err) // resolve error
 	}
 

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -94,7 +94,7 @@ var (
 // The isPredeclaredGlobal and isUniversal predicates report whether a
 // name is a pre-declared global identifier (in the current module) or a
 // universal identifier (in every module).
-// Typical values are globals.Has and Universe.has, respectively, where
+// Typical values are globals.Has and Universe.Has, respectively, where
 // globals is the current module's StringDict.
 func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) bool) error {
 	r := newResolver(isPredeclaredGlobal, isUniversal)
@@ -121,7 +121,7 @@ func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) 
 // The isPredeclaredGlobal and isUniversal predicates report whether a
 // name is a pre-declared global identifier (in the current module) or a
 // universal identifier (in every module).
-// Typical values are globals.Has and Universe.has, respectively, where
+// Typical values are globals.Has and Universe.Has, respectively, where
 // globals is the current module's StringDict.
 func Expr(expr syntax.Expr, isPredeclaredGlobal, isUniversal func(name string) bool) ([]*syntax.Ident, error) {
 	r := newResolver(isPredeclaredGlobal, isUniversal)

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -13,7 +13,7 @@
 package resolve
 
 // All references to names are statically resolved.  Names may be
-// built-in (e.g. None, len), global and predeclared (e.g. glob in the
+// universal (e.g. None, len), global and predeclared (e.g. glob in the
 // build language), global and user-defined (e.g. x=1 at toplevel), or
 // local to a function or module-level comprehension.  The resolver maps
 // each local name to a small integer for fast and compact
@@ -36,7 +36,7 @@ package resolve
 // As we finish resolving each function, we inspect all the uses within
 // that function and discard ones that were found to be local.  The
 // remaining ones must be either free (local to some lexically enclosing
-// function) or global/built-in, but we cannot tell which until we have
+// function) or global/universal, but we cannot tell which until we have
 // finished inspecting the outermost enclosing function.  At that point,
 // we can distinguish local from global names (and this is when Python
 // would compute free variables).
@@ -90,8 +90,14 @@ var (
 )
 
 // File resolves the specified file.
-func File(file *syntax.File, isPredeclaredGlobal, isBuiltin func(name string) bool) error {
-	r := newResolver(isPredeclaredGlobal, isBuiltin)
+//
+// The isPredeclaredGlobal and isUniversal predicates report whether a
+// name is a pre-declared global identifier (in the current module) or a
+// universal identifier (in every module).
+// Typical values are globals.Has and Universe.has, respectively, where
+// globals is the current module's StringDict.
+func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) bool) error {
+	r := newResolver(isPredeclaredGlobal, isUniversal)
 	r.stmts(file.Stmts)
 
 	r.env.resolveLocalUses()
@@ -111,11 +117,17 @@ func File(file *syntax.File, isPredeclaredGlobal, isBuiltin func(name string) bo
 
 // Expr resolves the specified expression.
 // It returns the local variables bound within the expression.
-func Expr(expr syntax.Expr, isPredeclaredGlobal, isBuiltin func(name string) bool) ([]*syntax.Ident, error) {
-	r := newResolver(isPredeclaredGlobal, isBuiltin)
+//
+// The isPredeclaredGlobal and isUniversal predicates report whether a
+// name is a pre-declared global identifier (in the current module) or a
+// universal identifier (in every module).
+// Typical values are globals.Has and Universe.has, respectively, where
+// globals is the current module's StringDict.
+func Expr(expr syntax.Expr, isPredeclaredGlobal, isUniversal func(name string) bool) ([]*syntax.Ident, error) {
+	r := newResolver(isPredeclaredGlobal, isUniversal)
 	r.expr(expr)
 	r.env.resolveLocalUses()
-	r.resolveNonLocalUses(r.env) // globals & builtins
+	r.resolveNonLocalUses(r.env) // globals & universals
 	if len(r.errors) > 0 {
 		return nil, r.errors
 	}
@@ -143,7 +155,7 @@ const (
 	Local                  // name is local to its function
 	Free                   // name is local to some enclosing function
 	Global                 // name is global to module
-	Builtin                // name is universal (e.g. len)
+	Universal              // name is universal (e.g. len)
 )
 
 var scopeNames = [...]string{
@@ -151,16 +163,16 @@ var scopeNames = [...]string{
 	Local:     "local",
 	Free:      "free",
 	Global:    "global",
-	Builtin:   "builtin",
+	Universal: "universal",
 }
 
 func (scope Scope) String() string { return scopeNames[scope] }
 
-func newResolver(isPredeclaredGlobal, isBuiltin func(name string) bool) *resolver {
+func newResolver(isPredeclaredGlobal, isUniversal func(name string) bool) *resolver {
 	return &resolver{
 		env:                 new(block), // module block
 		isPredeclaredGlobal: isPredeclaredGlobal,
-		isBuiltin:           isBuiltin,
+		isUniversal:         isUniversal,
 		globals:             make(map[string]syntax.Position),
 	}
 }
@@ -181,8 +193,8 @@ type resolver struct {
 	globals map[string]syntax.Position
 
 	// These predicates report whether a name is
-	// a pre-declared global or built-in.
-	isPredeclaredGlobal, isBuiltin func(name string) bool
+	// a pre-declared global or universal.
+	isPredeclaredGlobal, isUniversal func(name string) bool
 
 	loops int // number of enclosing for loops
 
@@ -326,8 +338,8 @@ func (r *resolver) useGlobal(id *syntax.Ident) (scope Scope) {
 		scope = Global // use of pre-declared global
 	} else if id.Name == "PACKAGE_NAME" {
 		scope = Global // nasty hack in Skylark spec; will go away (b/34240042).
-	} else if r.isBuiltin(id.Name) {
-		scope = Builtin // use of built-in
+	} else if r.isUniversal(id.Name) {
+		scope = Universal // use of universal name
 		if !AllowFloat && id.Name == "float" {
 			r.errorf(id.NamePos, doesnt+"support floating point")
 		}
@@ -737,7 +749,7 @@ func (r *resolver) lookupLexical(id *syntax.Ident, env *block) (bind binding) {
 
 	// Is this the module block?
 	if env.isModule() {
-		return binding{r.useGlobal(id), 0} // global or builtin, or not found
+		return binding{r.useGlobal(id), 0} // global or universal, or not found
 	}
 
 	// Defined in this block?

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -31,7 +31,7 @@ func TestResolve(t *testing.T) {
 		resolve.AllowSet = option(chunk.Source, "set")
 		resolve.AllowGlobalReassign = option(chunk.Source, "global_reassign")
 
-		if err := resolve.File(f, isPredeclaredGlobal, isBuiltin); err != nil {
+		if err := resolve.File(f, isPredeclaredGlobal, isUniversal); err != nil {
 			for _, err := range err.(resolve.ErrorList) {
 				chunk.GotError(int(err.Pos.Line), err.Msg)
 			}
@@ -50,7 +50,7 @@ func TestDefVarargsAndKwargsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resolve.File(file, isPredeclaredGlobal, isBuiltin); err != nil {
+	if err := resolve.File(file, isPredeclaredGlobal, isUniversal); err != nil {
 		t.Fatal(err)
 	}
 	fn := file.Stmts[0].(*syntax.DefStmt)
@@ -69,7 +69,7 @@ func TestLambdaVarargsAndKwargsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resolve.File(file, isPredeclaredGlobal, isBuiltin); err != nil {
+	if err := resolve.File(file, isPredeclaredGlobal, isUniversal); err != nil {
 		t.Fatal(err)
 	}
 	lam := file.Stmts[0].(*syntax.AssignStmt).RHS.(*syntax.LambdaExpr)
@@ -82,6 +82,6 @@ func TestLambdaVarargsAndKwargsSet(t *testing.T) {
 }
 
 func isPredeclaredGlobal(name string) bool { return strings.HasPrefix(name, "G") }
-func isBuiltin(name string) bool {
+func isUniversal(name string) bool {
 	return strings.HasPrefix(name, "B") || name == "float"
 }


### PR DESCRIPTION
- document these parameters
- rename isBuiltin to isUniversal to avoid overloading 'builtin' (as in functions)
- export StringDict.Has method, and simplify.

Change-Id: Ic53e963c7af5036c64672cba260c39e48feee209