### PR TITLE
sorted, cmp: follow Python-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ coins = {
   'quarter': 25,
 }
 print('By name:\t' + ', '.join(sorted(coins.keys())))
-print('By value:\t' + ', '.join(sorted(coins.keys(), cmp=lambda x, y: coins[x] - coins[y])))
+print('By value:\t' + ', '.join(sorted(coins.keys(), key=coins.get)))
 
 $ ./skylark -lambda coins.sky
 By name:	dime, nickel, penny, quarter

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2774,14 +2774,6 @@ See also: `ord`.
 
 <b>Implementation note:</b> `chr` is not provided by the Java implementation.
 
-### cmp
-
-`cmp(x, y)` compares two values `x` and `y` and returns an integer according to the outcome.
-The result is negative if `x < y`, positive if `x > y`, and zero otherwise.
-Consequently, `cmp(x, x)` always returns zero, even for floating-point NaN values.
-
-<b>Implementation note:</b> `cmp` is not provided by the Java implementation.
-
 ### dict
 
 `dict` creates a dictionary.  It accepts up to one positional
@@ -3051,28 +3043,27 @@ Sets are an optional feature of the Go implementation of Skylark.
 
 ### sorted
 
-`sorted(x)` returns a new list containing the elements of the iterable sequence x, in sorted order.
+`sorted(x)` returns a new list containing the elements of the iterable sequence x,
+in sorted order.  The sort algorithm is stable.
 
 The optional named parameter `reversed`, if true, causes `sorted` to
 return results in reverse sorted order.
 
-The optional named parameter `cmp` specifies an alternative function
-for ordered comparison of two elements.
+The optional named parameter `key` specifies a function of one
+argument to apply to obtain the value's sort key.
+The default behavior is the identity function.
 
 ```python
 sorted(set("harbors".split_codepoints()))                       # ['a', 'b', 'h', 'o', 'r', 's']
 sorted([3, 1, 4, 1, 5, 9])                                      # [1, 1, 3, 4, 5, 9]
 sorted([3, 1, 4, 1, 5, 9], reverse=True)                        # [9, 5, 4, 3, 1, 1]
 
-def cmplen(x, y): return len(x) - len(y)
-
-sorted(["two", "three", "four"], cmp=cmplen)                    # ["two", "four", "three"], shortest to longest
-sorted(["two", "three", "four"], cmp=cmplen, reverse=True)      # ["three", "four", "two"], longest to shortest
+sorted(["two", "three", "four"], key=len)                       # ["two", "four", "three"], shortest to longest
+sorted(["two", "three", "four"], key=len, reverse=True)         # ["three", "four", "two"], longest to shortest
 ```
 
 <b>Implementation note:</b>
-The Java implementation does not support the `cmp`, `key`, and
-`reversed` parameters.
+The Java implementation does not support the `key`, and `reversed` parameters.
 
 ### str
 

--- a/library.go
+++ b/library.go
@@ -43,7 +43,6 @@ func init() {
 		"all":       NewBuiltin("all", all),
 		"bool":      NewBuiltin("bool", bool_),
 		"chr":       NewBuiltin("chr", chr),
-		"cmp":       NewBuiltin("cmp", cmp),
 		"dict":      NewBuiltin("dict", dict),
 		"dir":       NewBuiltin("dir", dir),
 		"enumerate": NewBuiltin("enumerate", enumerate),
@@ -383,6 +382,7 @@ func bool_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 	return x.Truth(), nil
 }
 
+// https://github.com/google/skylark/blob/master/doc/spec.md#chr
 func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("chr does not accept keyword arguments")
@@ -401,29 +401,6 @@ func chr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 		return nil, fmt.Errorf("chr: Unicode code point U+%X out of range (>0x10FFFF)", i)
 	}
 	return String(string(i)), nil
-}
-
-// https://github.com/google/skylark/blob/master/doc/spec.md#cmp
-func cmp(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
-	if len(kwargs) > 0 {
-		return nil, fmt.Errorf("cmp does not accept keyword arguments")
-	}
-	if len(args) != 2 {
-		return nil, fmt.Errorf("cmp: got %d arguments, want 2", len(args))
-	}
-	x := args[0]
-	y := args[1]
-	if lt, err := Compare(syntax.LT, x, y); err != nil {
-		return nil, err
-	} else if lt {
-		return MakeInt(+1), nil // x < y
-	}
-	if gt, err := Compare(syntax.GT, x, y); err != nil {
-		return nil, err
-	} else if gt {
-		return MakeInt(-1), nil // x > y
-	}
-	return zero, nil // x == y or one of the operands is NaN
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#dict
@@ -774,6 +751,7 @@ func minmax(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, err
 	return extremum, nil
 }
 
+// https://github.com/google/skylark/blob/master/doc/spec.md#ord
 func ord(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	if len(kwargs) > 0 {
 		return nil, fmt.Errorf("ord does not accept keyword arguments")
@@ -918,11 +896,11 @@ func set(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 // https://github.com/google/skylark/blob/master/doc/spec.md#sorted
 func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
-	var cmp Callable
+	var key Callable
 	var reverse bool
 	if err := UnpackArgs("sorted", args, kwargs,
 		"iterable", &iterable,
-		"cmp?", &cmp,
+		"key?", &key,
 		"reverse?", &reverse,
 	); err != nil {
 		return nil, err
@@ -930,52 +908,60 @@ func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 
 	iter := iterable.Iterate()
 	defer iter.Done()
-	var elems []Value
+	var values []Value
 	if n := Len(iterable); n > 0 {
-		elems = make(Tuple, 0, n) // preallocate if length is known
+		values = make(Tuple, 0, n) // preallocate if length is known
 	}
 	var x Value
 	for iter.Next(&x) {
-		elems = append(elems, x)
+		values = append(values, x)
 	}
-	slice := &sortSlice{thread: thread, elems: elems, cmp: cmp}
+
+	// Derive keys from values by applying key function.
+	var keys []Value
+	if key != nil {
+		keys = make([]Value, len(values))
+		for i, v := range values {
+			k, err := Call(thread, key, Tuple{v}, nil)
+			if err != nil {
+				return nil, err // to preserve backtrace, don't modify error
+			}
+			keys[i] = k
+		}
+	}
+
+	slice := &sortSlice{keys: keys, values: values}
 	if reverse {
-		sort.Sort(sort.Reverse(slice))
+		sort.Stable(sort.Reverse(slice))
 	} else {
-		sort.Sort(slice)
+		sort.Stable(slice)
 	}
-	return NewList(slice.elems), slice.err
+	return NewList(slice.values), slice.err
 }
 
 type sortSlice struct {
-	thread *Thread
-	elems  []Value
-	cmp    Callable
+	keys   []Value // nil => values[i] is key
+	values []Value
 	err    error
-	pair   [2]Value
 }
 
-func (s *sortSlice) Len() int { return len(s.elems) }
+func (s *sortSlice) Len() int { return len(s.values) }
 func (s *sortSlice) Less(i, j int) bool {
-	x, y := s.elems[i], s.elems[j]
-	if s.cmp != nil {
-		// Strange things will happen if cmp fails, or returns a non-int.
-		s.pair[0], s.pair[1] = x, y // avoid allocation
-		res, err := Call(s.thread, s.cmp, Tuple(s.pair[:]), nil)
-		if err != nil {
-			s.err = err
-		}
-		cmp, ok := res.(Int)
-		return ok && cmp.Sign() < 0
+	keys := s.keys
+	if s.keys == nil {
+		keys = s.values
 	}
-	ok, err := Compare(syntax.LT, x, y)
+	ok, err := Compare(syntax.LT, keys[i], keys[j])
 	if err != nil {
 		s.err = err
 	}
 	return ok
 }
 func (s *sortSlice) Swap(i, j int) {
-	s.elems[i], s.elems[j] = s.elems[j], s.elems[i]
+	if s.keys != nil {
+		s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
+	}
+	s.values[i], s.values[j] = s.values[j], s.values[i]
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#str

--- a/testdata/builtins.sky
+++ b/testdata/builtins.sky
@@ -42,13 +42,19 @@ assert.eq(sorted(["wiz", "foo", "bar"]), ["bar", "foo", "wiz"])
 assert.eq(sorted(["wiz", "foo", "bar"], reverse=True), ["wiz", "foo", "bar"])
 assert.fails(lambda: sorted([1, 2, None, 3]), "int < NoneType not implemented")
 assert.fails(lambda: sorted([1, "one"]), "string < int not implemented")
-# custom cmp
-def cmplen(x, y): return len(x) - len(y)
-assert.eq(sorted(["two", "three", "four"], cmp=cmplen),
+# custom key function
+assert.eq(sorted(["two", "three", "four"], key=len),
           ["two", "four", "three"])
-assert.eq(sorted(["two", "three", "four"], cmp=cmplen, reverse=True),
+assert.eq(sorted(["two", "three", "four"], key=len, reverse=True),
           ["three", "four", "two"])
-assert.fails(lambda: sorted([1, 2, 3], cmp=None), "got NoneType, want callable")
+assert.fails(lambda: sorted([1, 2, 3], key=None), "got NoneType, want callable")
+# sort is stable
+pairs = [(4, 0), (3, 1), (4, 2), (2, 3), (3, 4), (1, 5), (2, 6), (3, 7)]
+assert.eq(sorted(pairs, key=lambda x: x[0]),
+          [(1, 5),
+           (2, 3), (2, 6),
+           (3, 1), (3, 4), (3, 7),
+           (4, 0), (4, 2)])
 
 # reversed
 assert.eq(reversed([1, 144, 81, 16]), [16, 81, 144, 1])

--- a/testdata/float.sky
+++ b/testdata/float.sky
@@ -110,7 +110,6 @@ assert.true(not nan <= nan)
 assert.true(not nan >= nan)
 assert.true(not nan == nan) # use explicit operator, not assert.ne
 assert.true(nan != nan)
-assert.eq(cmp(nan, nan), 0)
 assert.true(not nan < 0)
 assert.true(not nan > 0)
 assert.true(not [nan] < [nan])

--- a/testdata/misc.sky
+++ b/testdata/misc.sky
@@ -58,7 +58,6 @@ load("assert.sky", "assert")
 cyclic = [1, 2, 3] # list cycle
 cyclic[1] = cyclic
 assert.eq(str(cyclic), "[1, [...], 3]")
-assert.fails(lambda: cmp(cyclic, cyclic), "maximum recursion")
 assert.fails(lambda: cyclic < cyclic, "maximum recursion")
 assert.fails(lambda: cyclic == cyclic, "maximum recursion")
 cyclic2 = [1, 2, 3]


### PR DESCRIPTION
- remove Python-2 sorted(cmp=....) parameter
- add Python-3 sorted(key=...) parameter
- remove 'cmp' builtin, following Python-3
- use a stable sort