### PR TITLE
builtin: rename type to "builtin_function_or_method"

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1037,8 +1037,13 @@ over finite sequences, implies that Skylark programs are not Turing-complete.
 
 A built-in function is a function or method implemented in Go by the interpreter
 or the application into which the interpreter is embedded.
-The [type](#type) of a built-in function is `"builtin_function_or_method"`.
 A built-in function value used in a Boolean context is always considered true.
+
+The [type](#type) of a built-in function is `"builtin_function_or_method"`.
+<b>Implementation note:</b>
+The Java implementation of `type(x)` returns `"function"` for all
+functions, whether built in or defined in Skylark,
+even though applications distinguish these two types.
 
 Many built-in functions are defined in the "universe" block of the environment
 (see [Name Resolution](#name-resolution)), and are thus available to
@@ -3915,3 +3920,4 @@ eventually to eliminate all such differences on a case-by-case basis.
 * `hash` accepts operands besides strings.
 * `sorted` accepts the additional parameters `cmp`, `key`, and `reversed`.
 * The `dict` type has a `clear` method.
+* `type(x)` returns `"builtin_function_or_method"` for built-in functions.

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1813,7 +1813,7 @@ String interpolation
 
 Sets
       int | int                 # bitwise union (OR)
-      set | iterable            # set union
+      set | set                 # set union
       int & int                 # bitwise intersection (AND)
       set & set                 # set intersection
 ```
@@ -1864,9 +1864,7 @@ elements of the operand sets, preserving the element order of the left
 operand.
 
 The `|` operator likewise computes bitwise or set unions.
-However, if the left operand of `|` is a set, the right operand may be
-any iterable, not necessarily another set.
-The result of `set | iterable` is a new set whose elements are the
+The result of `set | set` is a new set whose elements are the
 union of the operands, preserving the order of the elements of the
 operands, left before right.
 
@@ -1876,7 +1874,6 @@ operands, left before right.
 
 set([1, 2]) & set([2, 3])       # set([2])
 set([1, 2]) | set([2, 3])       # set([1, 2, 3])
-set([1, 2]) | [2,3]             # set([1, 2, 3])
 ```
 
 <b>Implementation note:</b>

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1037,13 +1037,14 @@ over finite sequences, implies that Skylark programs are not Turing-complete.
 
 A built-in function is a function or method implemented in Go by the interpreter
 or the application into which the interpreter is embedded.
-A built-in function value used in a Boolean context is always considered true.
 
 The [type](#type) of a built-in function is `"builtin_function_or_method"`.
 <b>Implementation note:</b>
 The Java implementation of `type(x)` returns `"function"` for all
 functions, whether built in or defined in Skylark,
 even though applications distinguish these two types.
+
+A built-in function value used in a Boolean context is always considered true.
 
 Many built-in functions are defined in the "universe" block of the environment
 (see [Name Resolution](#name-resolution)), and are thus available to

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -70,7 +70,7 @@ concurrency, and other such features of Python.
     * [Dictionaries](#dictionaries)
     * [Sets](#sets)
     * [Functions](#functions)
-    * [Built-ins](#built-ins)
+    * [Built-in functions](#built-in-functions)
   * [Name binding and variables](#name-binding-and-variables)
   * [Value concepts](#value-concepts)
     * [Identity and mutation](#identity-and-mutation)
@@ -335,17 +335,17 @@ TODO: define string_lit, indent, outdent, semicolon, newline, eof
 These are the main data types built in to the interpreter:
 
 ```shell
-NoneType           # the type of None
-bool               # True or False
-int                # a signed integer of arbitrary magnitude
-float              # an IEEE 754 double-precision floating point number
-string             # a byte string
-list               # a fixed-length sequence of values
-tuple              # a fixed-length sequence of values, unmodifiable
-dict               # a mapping from values to values
-set                # a set of values
-function           # a function implemented in Skylark
-builtin            # a function or method implemented by the interpreter or host application
+NoneType                     # the type of None
+bool                         # True or False
+int                          # a signed integer of arbitrary magnitude
+float                        # an IEEE 754 double-precision floating point number
+string                       # a byte string
+list                         # a fixed-length sequence of values
+tuple                        # a fixed-length sequence of values, unmodifiable
+dict                         # a mapping from values to values
+set                          # a set of values
+function                     # a function implemented in Skylark
+builtin_function_or_method   # a function or method implemented by the interpreter or host application
 ```
 
 Some functions, such as the iteration methods of `string`, or the
@@ -1033,18 +1033,18 @@ over finite sequences, implies that Skylark programs are not Turing-complete.
 
 
 
-### Built-ins
+### Built-in functions
 
-A Built-in is a function or method implemented in Go by the interpreter
+A built-in function is a function or method implemented in Go by the interpreter
 or the application into which the interpreter is embedded.
-The [type](#type) of a built-in is `"builtin"`.
-A builtin value used in a Boolean context is always considered true.
+The [type](#type) of a built-in function is `"builtin_function_or_method"`.
+A built-in function value used in a Boolean context is always considered true.
 
-Many built-ins are defined in the "universe" block of the environment
+Many built-in functions are defined in the "universe" block of the environment
 (see [Name Resolution](#name-resolution)), and are thus available to
 all Skylark programs.
 
-Except where noted, built-ins accept only positional arguments.
+Except where noted, built-in functions accept only positional arguments.
 The parameter names serve merely as documentation.
 
 ## Name binding and variables
@@ -1338,7 +1338,7 @@ immutable due to _freezing_.
 A `tuple` value is hashable only if all its elements are hashable.
 Thus `("localhost", 80)` is hashable but `([127, 0, 0, 1], 80)` is not.
 
-Values of the types `function` and `builtin` are also hashable.
+Values of the types `function` and `builtin_function_or_method` are also hashable.
 Although functions are not necessarily immutable, as they may be
 closures that refer to mutable variables, instances of these types
 are compared by reference identity (see [Comparisons](#comparisons)),
@@ -1774,14 +1774,14 @@ comparison.
 
 The remaining built-in types support only equality comparisons.
 Values of type `dict` or `set` compare equal if their elements compare
-equal, and values of type `function` or `builtin` are equal only to
+equal, and values of type `function` or `builtin_function_or_method` are equal only to
 themselves.
 
 ```shell
-dict            # equal contents
-set             # equal contents
-function        # identity
-builtin         # identity
+dict                            # equal contents
+set                             # equal contents
+function                        # identity
+builtin_function_or_method      # identity
 ```
 
 #### Arithmetic operations
@@ -2086,7 +2086,7 @@ Arguments = Argument {',' Argument} .
 Argument  = identifier | identifier '=' Test | '*' identifier | '**' identifier .
 ```
 
-A value `f` of type `function` or `builtin` may be called using the expression `f(...)`.
+A value `f` of type `function` or `builtin_function_or_method` may be called using the expression `f(...)`.
 Applications may define additional types whose values may be called in the same way.
 
 A method call such as `filename.endswith(".sky")` is the composition
@@ -2116,7 +2116,7 @@ DotSuffix = '.' identifier .
 A dot expression fails if the value does not have an attribute of the
 specified name.
 
-Use the built-in `hasattr(x, "f")` function to ascertain whether a
+Use the built-in function `hasattr(x, "f")` to ascertain whether a
 value has a specific attribute, or `dir(x)` to enumerate all its
 attributes.  The `getattr(x, "f")` function can be used to select an
 attribute when the name `"f"` is not known statically.
@@ -3895,20 +3895,20 @@ eventually to eliminate all such differences on a case-by-case basis.
 * Integers are represented with infinite precision.
 * Integer arithmetic is exact.
 * Floating-point literals are supported (option: `-float`).
-* The `float` built-in is provided (option: `-float`).
+* The `float` built-in function is provided (option: `-float`).
 * Real division using `float / float` is supported (option: `-float`).
 * `def` statements may be nested (option: `-nesteddef`).
 * `lambda` expressions are supported (option: `-lambda`).
 * String elements are bytes.
 * Non-ASCII strings are encoded using UTF-8.
 * Strings have the additional methods `bytes`, `split_bytes`, `codepoints`, and `split_codepoints`.
-* The `chr` and `ord` built-ins are supported.
-* The `set` built-in is provided (option: `-set`).
+* The `chr` and `ord` built-in functions are supported.
+* The `set` built-in function is provided (option: `-set`).
 * `x += y` rebindings are permitted at top level.
 * `assert` is a valid identifier.
 * `&` is a token; `int & int` and `set & set` are supported.
 * `int | int` is supported.
-* The `freeze` built-in is provided (option: `-freeze`).
+* The `freeze` built-in function is provided (option: `-freeze`).
 * The parser accepts unary `+` expressions.
 * A method call `x.f()` may be separated into two steps: `y = x.f; y()`.
 * Dot expressions may appear on the left side of an assignment: `x.f = 1`.

--- a/eval.go
+++ b/eval.go
@@ -1178,7 +1178,8 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 				return x.Or(y), nil
 			}
 		case *Set: // union
-			if iter := Iterate(y); iter != nil {
+			if y, ok := y.(*Set); ok {
+				iter := Iterate(y)
 				defer iter.Done()
 				return x.Union(iter)
 			}

--- a/library.go
+++ b/library.go
@@ -337,7 +337,7 @@ func unpackOneArg(v Value, ptr interface{}) error {
 	return nil
 }
 
-// ---- builtin functions ----
+// ---- built-in functions ----
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#all
 func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {

--- a/skylarkstruct/struct.go
+++ b/skylarkstruct/struct.go
@@ -282,7 +282,7 @@ func writeJSON(out *bytes.Buffer, v skylark.Value) error {
 		}
 		out.WriteByte('}')
 	default:
-		// function, builtin, set, dict, and all user-defined types.
+		// function, builtin_function_or_method, set, dict, and all user-defined types.
 		return fmt.Errorf("cannot convert %s to JSON", v.Type())
 	}
 	return nil

--- a/testdata/assign.sky
+++ b/testdata/assign.sky
@@ -195,18 +195,18 @@ z += 3 ### "global variable z referenced before assignment"
 
 load("assert.sky", "assert")
 
-assert.eq(type(list), "builtin")
+assert.eq(type(list), "builtin_function_or_method")
 list = []
 assert.eq(type(list), "list")
 
 # set and float are dialect-specific,
 # but we shouldn't notice any difference.
 
-assert.eq(type(float), "builtin")
+assert.eq(type(float), "builtin_function_or_method")
 float = 1.0
 assert.eq(type(float), "float")
 
-assert.eq(type(set), "builtin")
+assert.eq(type(set), "builtin_function_or_method")
 set = [1, 2, 3]
 assert.eq(type(set), "list")
 

--- a/testdata/builtins.sky
+++ b/testdata/builtins.sky
@@ -141,7 +141,7 @@ assert.eq(zip(z1), [(1,), (2,)])
 assert.fails(lambda: zip(z1, 1), "zip: argument #2 is not iterable: int")
 z1.append(3)
 
-# dir for builtins
+# dir for builtin_function_or_method
 assert.eq(dir(None), [])
 assert.eq(dir({})[:3], ["clear", "get", "items"]) # etc
 assert.eq(dir(1), [])

--- a/testdata/function.sky
+++ b/testdata/function.sky
@@ -96,7 +96,7 @@ yang(True)
 assert.eq(calls, ["yang", "yin"])
 
 
-# hash(builtin) should be deterministic.
+# hash(builtin_function_or_method) should be deterministic.
 closures = set(["".count for _ in range(10)])
 assert.eq(len(closures), 10)
 hashes = set([hash("".count) for _ in range(10)])

--- a/testdata/set.sky
+++ b/testdata/set.sky
@@ -31,8 +31,10 @@ assert.eq(type(set([1, 3, 2, 3])), "set")
 assert.eq(list(set([1, 3, 2, 3])), [1, 3, 2])
 assert.eq(type(set("hello".split_bytes())), "set")
 assert.eq(list(set("hello".split_bytes())), ["h", "e", "l", "o"])
+assert.eq(list(set(range(3))), [0, 1, 2])
 assert.fails(lambda: set(1), "got int, want iterable")
 assert.fails(lambda: set(1, 2, 3), "got 3 arguments")
+assert.fails(lambda: set([1, 2, {}]), "unhashable type: dict")
 
 # truth
 assert.true(not set())
@@ -45,22 +47,28 @@ y = set([3, 4, 5])
 # set + any is not defined
 assert.fails(lambda: x + y, "unknown.*: set \+ set")
 
-# union, set | iterable
+# set | set
 assert.eq(list(set("a".split_bytes()) | set("b".split_bytes())), ["a", "b"])
 assert.eq(list(set("ab".split_bytes()) | set("bc".split_bytes())), ["a", "b", "c"])
-assert.eq(list(set("ab".split_bytes()) | "bc".split_bytes()), ["a", "b", "c"])
+assert.fails(lambda: set() | [], "unknown binary op: set | list")
 assert.eq(type(x | y), "set")
 assert.eq(list(x | y), [1, 2, 3, 4, 5])
-assert.eq(list(x | [5, 1]), [1, 2, 3, 5])
-assert.eq(list(x | (6, 5, 4)), [1, 2, 3, 6, 5, 4])
-assert.fails(lambda: x | [1, 2, {}], "unhashable type: dict")
+assert.eq(list(x | set([5, 1])), [1, 2, 3, 5])
+assert.eq(list(x | set((6, 5, 4))), [1, 2, 3, 6, 5, 4])
+
+# set.union (allows any iterable for right operand)
+assert.eq(list(set("a".split_bytes()).union("b".split_bytes())), ["a", "b"])
+assert.eq(list(set("ab".split_bytes()).union("bc".split_bytes())), ["a", "b", "c"])
+assert.eq(set().union([]), set())
+assert.eq(type(x.union(y)), "set")
+assert.eq(list(x.union(y)), [1, 2, 3, 4, 5])
+assert.eq(list(x.union([5, 1])), [1, 2, 3, 5])
+assert.eq(list(x.union((6, 5, 4))), [1, 2, 3, 6, 5, 4])
+assert.fails(lambda: x.union([1, 2, {}]), "unhashable type: dict")
 
 # intersection, set & set
 assert.eq(list(set("a".split_bytes()) & set("b".split_bytes())), [])
 assert.eq(list(set("ab".split_bytes()) & set("bc".split_bytes())), ["b"])
-
-# set.union
-assert.eq(list(x.union(y)), [1, 2, 3, 4, 5])
 
 # len
 assert.eq(len(x), 3)
@@ -68,8 +76,9 @@ assert.eq(len(y), 3)
 assert.eq(len(x | y), 5)
 
 # str
-# TODO(adonovan): make output deterministic when len > 1?
 assert.eq(str(set([1])), "set([1])")
+assert.eq(str(set([2, 3])), "set([2, 3])")
+assert.eq(str(set([3, 2])), "set([3, 2])")
 
 # comparison
 assert.eq(x, x)

--- a/value.go
+++ b/value.go
@@ -17,7 +17,7 @@
 //      *Dict           -- dict
 //      *Set            -- set
 //      *Function       -- function (implemented in Skylark)
-//      *Builtin        -- builtin (function or method implemented in Go)
+//      *Builtin        -- builtin_function_or_method (function or method implemented in Go)
 //
 // Client applications may define new data types that satisfy at least
 // the Value interface.  Such types may provide additional operations by
@@ -495,13 +495,13 @@ func (b *Builtin) Hash() (uint32, error) {
 }
 func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
-func (b *Builtin) Type() string    { return "builtin" }
+func (b *Builtin) Type() string    { return "builtin_function_or_method" }
 func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
 	return b.fn(thread, b, args, kwargs)
 }
 func (b *Builtin) Truth() Bool { return true }
 
-// NewBuiltin returns a new 'builtin' value with the specified name
+// NewBuiltin returns a new 'builtin_function_or_method' value with the specified name
 // and implementation.  It compares unequal with all other values.
 func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)) *Builtin {
 	return &Builtin{name: name, fn: fn}
@@ -510,8 +510,8 @@ func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kw
 // BindReceiver returns a new Builtin value representing a method
 // closure, that is, a built-in function bound to a receiver value.
 //
-// In the example below, the value of f is the string.index builtin bound to
-// the receiver value "abc":
+// In the example below, the value of f is the string.index
+// built-in method bound to the receiver value "abc":
 //
 //     f = "abc".index; f("a"); f("b")
 //


### PR DESCRIPTION
Also:
- remove all uses of "builtin" as a noun.
  Now it's always "built-in function" (or method).
