### PR TITLE
syntax: fix scanner position reporting 

### DIFF
--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -594,6 +594,7 @@ start:
 	defer sc.endToken(val)
 	switch c {
 	case '=', '<', '>', '!', '+', '-', '%', '/': // possibly followed by '='
+		start := sc.pos
 		sc.readRune()
 		if sc.peekRune() == '=' {
 			sc.readRune()
@@ -624,7 +625,7 @@ start:
 		case '>':
 			return GT
 		case '!':
-			sc.error(sc.pos, "unexpected input character '!'")
+			sc.error(start, "unexpected input character '!'")
 		case '+':
 			return PLUS
 		case '-':
@@ -677,6 +678,7 @@ start:
 }
 
 func (sc *scanner) scanString(val *tokenValue, quote rune) Token {
+	start := sc.pos
 	triple := len(sc.rest) >= 3 && sc.rest[0] == byte(quote) && sc.rest[1] == byte(quote) && sc.rest[2] == byte(quote)
 	sc.readRune()
 	if triple {
@@ -712,7 +714,7 @@ func (sc *scanner) scanString(val *tokenValue, quote rune) Token {
 	sc.endToken(val)
 	s, _, err := unquote(val.raw)
 	if err != nil {
-		sc.error(sc.pos, err.Error())
+		sc.error(start, err.Error())
 	}
 	val.string = s
 	return STRING
@@ -727,6 +729,7 @@ func (sc *scanner) scanNumber(val *tokenValue, c rune) Token {
 	// - traditional octal: 0755
 	// https://docs.python.org/2/reference/lexical_analysis.html#integer-and-long-integer-literals
 
+	start := sc.pos
 	fraction, exponent := false, false
 
 	if c == '.' {
@@ -750,7 +753,7 @@ func (sc *scanner) scanNumber(val *tokenValue, c rune) Token {
 			sc.readRune()
 			c = sc.peekRune()
 			if !isxdigit(c) {
-				sc.error(sc.pos, "invalid hex literal")
+				sc.error(start, "invalid hex literal")
 			}
 			for isxdigit(c) {
 				sc.readRune()
@@ -854,7 +857,7 @@ func (sc *scanner) scanNumber(val *tokenValue, c rune) Token {
 			val.int, err = strconv.ParseInt(s, 0, 64)
 		}
 		if err != nil {
-			sc.error(sc.pos, "invalid int literal")
+			sc.error(start, "invalid int literal")
 		}
 		return INT
 	}

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -155,9 +155,9 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		// hex
 		{"0xA", `10 EOF`},
 		{"0xAAG", `170 G EOF`},
-		{"0xG", `invalid hex literal`},
+		{"0xG", `foo.sky:1:1: invalid hex literal`},
 		{"0XA", `10 EOF`},
-		{"0XG", `invalid hex literal`},
+		{"0XG", `foo.sky:1:1: invalid hex literal`},
 		{"0xA.", `10 . EOF`},
 		{"0xA.e1", `10 . e1 EOF`},
 		// octal
@@ -172,13 +172,14 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		// TODO(adonovan): reenable later.
 		// {"0123", `obsolete form of octal literal; use 0o123`},
 		{"0123", `83 EOF`},
-		{"012834", `invalid int literal`},
-		{"012934", `invalid int literal`},
+		{"012834", `foo.sky:1:1: invalid int literal`},
+		{"012934", `foo.sky:1:1: invalid int literal`},
+		{"i = 012934", `foo.sky:1:5: invalid int literal`},
 		// octal escapes in string literals
 		{`"\037"`, `"\x1f" EOF`},
 		{`"\377"`, `"\xff" EOF`},
-		{`"\378"`, `"\x1f8" EOF`},                  // = '\37' + '8'
-		{`"\400"`, `invalid escape sequence \400`}, // unlike Python 2 and 3
+		{`"\378"`, `"\x1f8" EOF`},                               // = '\37' + '8'
+		{`"\400"`, `foo.sky:1:1: invalid escape sequence \400`}, // unlike Python 2 and 3
 		// Backslashes that are not part of escapes are treated literally,
 		// but this behavior will change; see b/34519173.
 		{`"\+"`, `"\\+" EOF`},
@@ -189,10 +190,12 @@ pass`, "pass newline pass EOF"}, // consecutive newlines are consolidated
 		{"012934e1", `1.293400e+05 EOF`},
 		{"0123.", `1.230000e+02 EOF`},
 		{"0123.1", `1.231000e+02 EOF`},
+		// issue #16
+		{"x ! 0", "foo.sky:1:3: unexpected input character '!'"},
 	} {
 		got, err := scan(test.input)
 		if err != nil {
-			got = err.(Error).Msg
+			got = err.(Error).Error()
 		}
 		if test.want != got {
 			t.Errorf("scan `%s` = [%s], want [%s]", test.input, got, test.want)


### PR DESCRIPTION
This is a minor fix for #16. I also change the current test to print the whole error message.

update: I thought about it, and maybe it's better to add a `start` field to the scanner, that will represent the start position of a token. wdyt? 