### PR TITLE
hashtable: add seed parameter to Value.Hash function

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1330,7 +1330,8 @@ dynamic error.
 
 The hash of a value is an unspecified integer chosen so that two equal
 values have the same hash, in other words, `x == y => hash(x) == hash(y)`.
-A hashable value has the same hash throughout its lifetime.
+A hashable value has the same hash throughout its lifetime,
+though the hash may vary from one execution of a program to the next.
 
 Values of the types `NoneType`, `bool`, `int`, `float`, and `string`,
 which are all immutable, are hashable.
@@ -2885,6 +2886,8 @@ getattr("banana", "split")("a")	       # ["b", "n", "n", ""], equivalent to "ban
 `hash(x)` returns an integer hash value for x such that `x == y` implies `hash(x) == hash(y)`.
 
 `hash` fails if x, or any value upon which its hash depends, is unhashable.
+
+The hash function may vary from one execution of a program to the next.
 
 <b>Implementation note:</b> the Java implementation of the `hash`
 function accepts only strings.

--- a/eval_test.go
+++ b/eval_test.go
@@ -145,12 +145,12 @@ func TestExecFile(t *testing.T) {
 // A fib is an iterable value representing the infinite Fibonacci sequence.
 type fib struct{}
 
-func (t fib) Freeze()                   {}
-func (t fib) String() string            { return "fib" }
-func (t fib) Type() string              { return "fib" }
-func (t fib) Truth() skylark.Bool       { return true }
-func (t fib) Hash() (uint32, error)     { return 0, fmt.Errorf("fib is unhashable") }
-func (t fib) Iterate() skylark.Iterator { return &fibIterator{0, 1} }
+func (t fib) Freeze()                     {}
+func (t fib) String() string              { return "fib" }
+func (t fib) Type() string                { return "fib" }
+func (t fib) Truth() skylark.Bool         { return true }
+func (t fib) Hash(uint32) (uint32, error) { return 0, fmt.Errorf("fib is unhashable") }
+func (t fib) Iterate() skylark.Iterator   { return &fibIterator{0, 1} }
 
 type fibIterator struct{ x, y int }
 
@@ -189,10 +189,10 @@ type hasfields struct {
 
 var _ skylark.HasAttrs = (*hasfields)(nil)
 
-func (hf *hasfields) String() string        { return "hasfields" }
-func (hf *hasfields) Type() string          { return "hasfields" }
-func (hf *hasfields) Truth() skylark.Bool   { return true }
-func (hf *hasfields) Hash() (uint32, error) { return 42, nil }
+func (hf *hasfields) String() string                   { return "hasfields" }
+func (hf *hasfields) Type() string                     { return "hasfields" }
+func (hf *hasfields) Truth() skylark.Bool              { return true }
+func (hf *hasfields) Hash(seed uint32) (uint32, error) { return 42 * seed, nil }
 
 func (hf *hasfields) Freeze() {
 	if !hf.frozen {

--- a/int.go
+++ b/int.go
@@ -116,12 +116,13 @@ func (i Int) String() string { return i.bigint.String() }
 func (i Int) Type() string   { return "int" }
 func (i Int) Freeze()        {} // immutable
 func (i Int) Truth() Bool    { return i.Sign() != 0 }
-func (i Int) Hash() (uint32, error) {
-	var lo big.Word
-	if i.bigint.Sign() != 0 {
-		lo = i.bigint.Bits()[0]
+func (i Int) Hash(seed uint32) (uint32, error) {
+	h := seed
+	for _, w := range i.bigint.Bits() {
+		h ^= uint32(w)
+		h *= 12582917
 	}
-	return 12582917 * uint32(lo+3), nil
+	return h, nil
 }
 func (x Int) CompareSameType(op syntax.Token, y Value, depth int) (bool, error) {
 	return threeway(op, x.bigint.Cmp(y.(Int).bigint)), nil

--- a/library.go
+++ b/library.go
@@ -556,7 +556,8 @@ func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 	if err := UnpackPositionalArgs("hash", args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
-	h, err := x.Hash()
+	// TODO(adonovan): pick a random per-process seed on each run?
+	h, err := x.Hash(3321718769)
 	return MakeUint(uint(h)), err
 }
 
@@ -878,9 +879,9 @@ func (r rangeValue) String() string {
 		return fmt.Sprintf("range(%d)", r.stop)
 	}
 }
-func (r rangeValue) Type() string          { return "range" }
-func (r rangeValue) Truth() Bool           { return r.len > 0 }
-func (r rangeValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: range") }
+func (r rangeValue) Type() string                { return "range" }
+func (r rangeValue) Truth() Bool                 { return r.len > 0 }
+func (r rangeValue) Hash(uint32) (uint32, error) { return 0, fmt.Errorf("unhashable: range") }
 
 func (x rangeValue) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(rangeValue)

--- a/skylarkstruct/struct.go
+++ b/skylarkstruct/struct.go
@@ -318,7 +318,7 @@ func structsEqual(x, y *Struct, depth int) (bool, error) {
 	}
 
 	if eq, err := skylark.Equal(x.constructor, y.constructor); err != nil {
-		return false, fmt.Errorf("error comparing struct constructors: %v",
+		return false, fmt.Errorf("cannot compare struct constructors %v and %v: %v",
 			x.constructor, y.constructor, err)
 	} else if !eq {
 		return false, nil

--- a/skylarkstruct/struct.go
+++ b/skylarkstruct/struct.go
@@ -144,18 +144,18 @@ func (s *Struct) Constructor() skylark.Value { return s.constructor }
 
 func (s *Struct) Type() string        { return "struct" }
 func (s *Struct) Truth() skylark.Bool { return true } // even when empty
-func (s *Struct) Hash() (uint32, error) {
+func (s *Struct) Hash(seed uint32) (uint32, error) {
 	// Same algorithm as Tuple.hash, but with different primes.
-	var x, m uint32 = 8731, 9839
+	var x, mult uint32 = seed, 9839
 	for _, e := range s.entries {
-		namehash, _ := skylark.String(e.name).Hash()
-		x = x ^ 3*namehash
-		y, err := e.value.Hash()
+		namehash, _ := skylark.String(e.name).Hash(x)
+		x = 3 * namehash
+		y, err := e.value.Hash(x)
 		if err != nil {
 			return 0, err
 		}
-		x = x ^ y*m
-		m += 7349
+		x = y * mult
+		mult += 7349
 	}
 	return x, nil
 }

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -286,7 +286,7 @@ func (p *parser) parseLoadStmt() *LoadStmt {
 			id := p.parseIdent()
 			to = append(to, id)
 			if p.tok != EQ {
-				p.in.errorf(p.in.pos, `load operand must be "%s" or %s="originalname" (want '=' after %s)`, id.Name, id.Name)
+				p.in.errorf(p.in.pos, `load operand must be "%[1]s" or %[1]s="originalname" (want '=' after %[1]s)`, id.Name)
 			}
 			p.consume(EQ)
 			if p.tok != STRING {

--- a/syntax/testdata/errors.sky
+++ b/syntax/testdata/errors.sky
@@ -128,7 +128,7 @@ load("a", "x") # ok
 ---
 load(1, 2) ### "first operand of load statement must be a string literal"
 ---
-load("a", x) ### `load operand must be "x" or x="originalname"`
+load("a", x) ### `load operand must be "x" or x="originalname" \(want '=' after x\)`
 ---
 load("a", x2=x) ### `original name of loaded symbol must be quoted: x2="originalname"`
 ---


### PR DESCRIPTION
This makes it possible to defend against hash flooding attacks,
in which an attacker constructs a sequence of non-equal values with
the same hash, causing a hash table to degenerate to a linked list.
Each hash table supplies its own random seed when hashing each key.

(Further work is required to make the actual hash functions robust.)