### PR TITLE
feature request: expose Function FreeVars and Globals as a public API

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -488,3 +488,31 @@ func TestUnpackUserDefined(t *testing.T) {
 		t.Errorf("unpack args error = %q, want %q", err, want)
 	}
 }
+
+func TestFunctionAPI(t *testing.T) {
+	const src = `
+def f():
+  x = 1
+  y = 2
+  return lambda: x + 3
+
+result = f()
+`
+	thread := new(skylark.Thread)
+	globals := make(skylark.StringDict)
+	if err := skylark.ExecFile(thread, "function_api.go", src, globals); err != nil {
+		t.Fatal(err)
+	}
+
+	result, ok := globals["result"].(*skylark.Function)
+	if !ok {
+		t.Errorf("expected function, actual: %T", result)
+	}
+
+	freeVars := result.FreeVars()
+	if len(freeVars) != 1 {
+		t.Errorf("expected freevars: [1]. Actual: %+v", freeVars)
+	} else if val, ok := freeVars[0].(skylark.Int).Int64(); !ok || val != 1 {
+		t.Errorf("expected freevars: [1]. Actual: %+v", freeVars)
+	}
+}

--- a/value.go
+++ b/value.go
@@ -472,6 +472,8 @@ func (fn *Function) Type() string          { return "function" }
 func (fn *Function) Truth() Bool           { return true }
 
 func (fn *Function) Syntax() *syntax.Function { return fn.syntax }
+func (fn *Function) FreeVars() Tuple          { return fn.freevars }
+func (fn *Function) Globals() StringDict      { return fn.globals }
 
 // A Builtin is a function implemented in Go.
 type Builtin struct {


### PR DESCRIPTION
Background: We're using the skylark evaluation engine as a partial evaluator. 

As a toy example,
```
def main():
   return job_60s() + job_30s()
```
The partial evaluator can guess that main() takes 90s without actually running the two jobs.

This breaks down when we have free variables:
```
def main():
   result = job_60s()
   return lambda: result
```
because there's no way for the evaluator to figure out that the lambda depends on `result`. This PR adds an API to help figure that out.


