### PR TITLE
Attach comments to AST nodes.

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -255,7 +255,7 @@ func Exec(opts ExecOptions) error {
 		fmt.Printf("ExecFile %s\n", opts.Filename)
 		defer fmt.Printf("ExecFile %s done\n", opts.Filename)
 	}
-	f, err := syntax.Parse(opts.Filename, opts.Source)
+	f, err := syntax.Parse(opts.Filename, opts.Source, 0)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (thread *Thread) Pop() {
 // If Eval fails during evaluation, it returns an *EvalError
 // containing a backtrace.
 func Eval(thread *Thread, filename string, src interface{}, globals StringDict) (Value, error) {
-	expr, err := syntax.ParseExpr(filename, src)
+	expr, err := syntax.ParseExpr(filename, src, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -437,7 +437,7 @@ Error: floored division by zero`
 // TestRepeatedExec parses and resolves a file syntax tree once then
 // executes it repeatedly with different values of its global variables.
 func TestRepeatedExec(t *testing.T) {
-	f, err := syntax.Parse("repeat.sky", "y = 2 * x")
+	f, err := syntax.Parse("repeat.sky", "y = 2 * x", 0)
 	if err != nil {
 		t.Fatal(f) // parse error
 	}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -100,7 +100,7 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 	}
 
 	// If the line contains a well-formed expression, evaluate it.
-	if _, err := syntax.ParseExpr("<stdin>", line); err == nil {
+	if _, err := syntax.ParseExpr("<stdin>", line, 0); err == nil {
 		if v, err := skylark.Eval(thread, "<stdin>", line, globals); err != nil {
 			PrintError(err)
 		} else if v != skylark.None {
@@ -111,7 +111,7 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 
 	// If the input so far is a single load or assignment statement,
 	// execute it without waiting for a blank line.
-	if f, err := syntax.Parse("<stdin>", line); err == nil && len(f.Stmts) == 1 {
+	if f, err := syntax.Parse("<stdin>", line, 0); err == nil && len(f.Stmts) == 1 {
 		switch f.Stmts[0].(type) {
 		case *syntax.AssignStmt, *syntax.LoadStmt:
 			// Execute it as a file.
@@ -145,7 +145,7 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 	//     1,
 	//     2
 	//   )
-	if _, err := syntax.ParseExpr("<stdin>", text); err == nil {
+	if _, err := syntax.ParseExpr("<stdin>", text, 0); err == nil {
 		if v, err := skylark.Eval(thread, "<stdin>", text, globals); err != nil {
 			PrintError(err)
 		} else if v != skylark.None {
@@ -165,7 +165,7 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 // execFileNoFreeze is skylark.ExecFile without globals.Freeze().
 func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.StringDict) error {
 	// parse
-	f, err := syntax.Parse("<stdin>", src)
+	f, err := syntax.Parse("<stdin>", src, 0)
 	if err != nil {
 		return err
 	}

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -17,7 +17,7 @@ import (
 func TestResolve(t *testing.T) {
 	filename := skylarktest.DataFile("skylark/resolve", "testdata/resolve.sky")
 	for _, chunk := range chunkedfile.Read(filename, t) {
-		f, err := syntax.Parse(filename, chunk.Source)
+		f, err := syntax.Parse(filename, chunk.Source, 0)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -45,7 +45,7 @@ func option(chunk, name string) bool {
 
 func TestDefVarargsAndKwargsSet(t *testing.T) {
 	source := "def f(*args, **kwargs): pass\n"
-	file, err := syntax.Parse("foo.sky", source)
+	file, err := syntax.Parse("foo.sky", source, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestDefVarargsAndKwargsSet(t *testing.T) {
 func TestLambdaVarargsAndKwargsSet(t *testing.T) {
 	resolve.AllowLambda = true
 	source := "f = lambda *args, **kwargs: 0\n"
-	file, err := syntax.Parse("foo.sky", source)
+	file, err := syntax.Parse("foo.sky", source, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -16,9 +16,6 @@ import "log"
 // Enable this flag to print the token stream and log.Fatal on the first error.
 const debug = false
 
-// Enable this flag to attach comments to the AST.
-const keepComments = false
-
 type Mode uint
 
 const (
@@ -45,7 +42,7 @@ func Parse(filename string, src interface{}, mode Mode) (f *File, err error) {
 	if f != nil {
 		f.Path = filename
 	}
-	if keepComments {
+	if mode&RetainComments != 0 {
 		p.assignComments(f)
 	}
 	return f, nil
@@ -91,10 +88,8 @@ func (p *parser) nextToken() Position {
 	p.tok = p.in.nextToken(&p.tokval)
 	// save comments
 	for p.tok == LINE_COMMENT || p.tok == SUFFIX_COMMENT {
-		if keepComments {
-			suffix := p.tok == SUFFIX_COMMENT
-			p.comments = append(p.comments, Comment{p.tokval.pos, p.tokval.raw, suffix})
-		}
+		suffix := p.tok == SUFFIX_COMMENT
+		p.comments = append(p.comments, Comment{p.tokval.pos, p.tokval.raw, suffix})
 		p.tok = p.in.nextToken(&p.tokval)
 	}
 	// enable to see the token stream

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -75,10 +75,9 @@ func ParseExpr(filename string, src interface{}, mode Mode) (expr Expr, err erro
 }
 
 type parser struct {
-	in       *scanner
-	tok      Token
-	tokval   tokenValue
-	comments []Comment
+	in     *scanner
+	tok    Token
+	tokval tokenValue
 }
 
 // nextToken advances the scanner and returns the position of the
@@ -86,12 +85,6 @@ type parser struct {
 func (p *parser) nextToken() Position {
 	oldpos := p.tokval.pos
 	p.tok = p.in.nextToken(&p.tokval)
-	// save comments
-	for p.tok == LINE_COMMENT || p.tok == SUFFIX_COMMENT {
-		suffix := p.tok == SUFFIX_COMMENT
-		p.comments = append(p.comments, Comment{p.tokval.pos, p.tokval.raw, suffix})
-		p.tok = p.in.nextToken(&p.tokval)
-	}
 	// enable to see the token stream
 	if debug {
 		log.Printf("nextToken: %-20s%+v\n", p.tok, p.tokval.pos)
@@ -986,7 +979,7 @@ func (p *parser) assignComments(f *File) {
 
 	// Split into whole-line comments and suffix comments.
 	var line, suffix []Comment
-	for _, com := range p.comments {
+	for _, com := range p.in.comments {
 		if com.Suffix {
 			suffix = append(suffix, com)
 		} else {

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -994,26 +994,28 @@ func (p *parser) assignComments(f *File) {
 		}
 	}
 
-	// // Assign line comments to syntax immediately following.
+	// Assign line comments to syntax immediately following.
 	for _, x := range pre {
 		start, _ := x.Span()
-		xcom := x.Comment()
+		x.AllocComments()
+		xcom := x.Comments()
 
 		switch x.(type) {
 		case *File:
 			continue
 		}
 
-		for len(line) > 0 && !start.IsBefore(line[0].Start) {
+		for len(line) > 0 && !start.isBefore(line[0].Start) {
 			xcom.Before = append(xcom.Before, line[0])
 			line = line[1:]
 		}
 	}
 
 	// Remaining line comments go at end of file.
-	f.After = append(f.After, line...)
+	f.AllocComments()
+	f.Comments().After = append(f.Comments().After, line...)
 
-	// // Assign suffix comments to syntax immediately before.
+	// Assign suffix comments to syntax immediately before.
 	for i := len(post) - 1; i >= 0; i-- {
 		x := post[i]
 
@@ -1024,8 +1026,8 @@ func (p *parser) assignComments(f *File) {
 		}
 
 		_, end := x.Span()
-		xcom := x.Comment()
-		for len(suffix) > 0 && end.IsBefore(suffix[len(suffix)-1].Start) {
+		xcom := x.Comments()
+		for len(suffix) > 0 && end.isBefore(suffix[len(suffix)-1].Start) {
 			xcom.Suffix = append(xcom.Suffix, suffix[len(suffix)-1])
 			suffix = suffix[:len(suffix)-1]
 		}
@@ -1035,11 +1037,11 @@ func (p *parser) assignComments(f *File) {
 	// If multiple suffix comments were appended to the same
 	// expression node, they are now in reverse. Fix that.
 	for _, x := range post {
-		reverseComments(x.Comment().Suffix)
+		reverseComments(x.Comments().Suffix)
 	}
 
 	// Remaining suffix comments go at beginning of file.
-	f.Before = append(f.Before, suffix...)
+	f.Comments().Before = append(f.Comments().Before, suffix...)
 }
 
 // reverseComments reverses the []Comment list.

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -1016,16 +1016,10 @@ func (p *parser) assignComments(n Node) {
 		}
 
 		_, end := x.Span()
-		for len(suffix) > 0 && end.isBefore(suffix[len(suffix)-1].Start) {
+		if len(suffix) > 0 && end.isBefore(suffix[len(suffix)-1].Start) {
 			x.AllocComments()
 			x.Comments().Suffix = append(x.Comments().Suffix, suffix[len(suffix)-1])
 			suffix = suffix[:len(suffix)-1]
 		}
-	}
-
-	// Remaining suffix comments go at beginning of file.
-	if len(suffix) > 0 {
-		n.AllocComments()
-		n.Comments().Before = append(n.Comments().Before, suffix...)
 	}
 }

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -107,12 +107,13 @@ func TestExprParseTrees(t *testing.T) {
 		{`[e for x in y if cond1 if cond2]`,
 			`(Comprehension Body=e Clauses=((ForClause Vars=x X=y) (IfClause Cond=cond1) (IfClause Cond=cond2)))`}, // github.com/google/skylark issue 53
 	} {
-		e, err := syntax.ParseExpr("foo.sky", test.input)
+		e, err := syntax.ParseExpr("foo.sky", test.input, 0)
 		if err != nil {
 			t.Errorf("parse `%s` failed: %v", test.input, stripPos(err))
 			continue
 		}
 		if got := treeString(e); test.want != got {
+
 			t.Errorf("parse `%s` = %s, want %s", test.input, got, test.want)
 		}
 	}
@@ -175,7 +176,7 @@ def h():
 	pass`,
 			`(DefStmt Name=f Function=(Function Body=((DefStmt Name=g Function=(Function Body=((BranchStmt Token=pass)))) (BranchStmt Token=pass))))`},
 	} {
-		f, err := syntax.Parse("foo.sky", test.input)
+		f, err := syntax.Parse("foo.sky", test.input, 0)
 		if err != nil {
 			t.Errorf("parse `%s` failed: %v", test.input, stripPos(err))
 			continue
@@ -224,7 +225,7 @@ pass`,
 + 2`,
 			`(AssignStmt Op== LHS=x RHS=(BinaryExpr X=1 Op=+ Y=2))`},
 	} {
-		f, err := syntax.Parse("foo.sky", test.input)
+		f, err := syntax.Parse("foo.sky", test.input, 0)
 		if err != nil {
 			t.Errorf("parse `%s` failed: %v", test.input, stripPos(err))
 			continue
@@ -257,6 +258,7 @@ func stripPos(err error) string {
 func treeString(n syntax.Node) string {
 	var buf bytes.Buffer
 	writeTree(&buf, reflect.ValueOf(n))
+	// Skip comments fields
 	return buf.String()
 }
 
@@ -290,6 +292,10 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 				continue // skip positions
 			}
 			name := x.Type().Field(i).Name
+			//strings.Replace(, " Comments=(Comments)", "", -1)
+			if name == "Comments" {
+				continue // skip comments fields
+			}
 			if f.Type() == reflect.TypeOf(syntax.Token(0)) {
 				fmt.Fprintf(out, " %s=%s", name, f.Interface())
 				continue
@@ -330,7 +336,7 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 func TestParseErrors(t *testing.T) {
 	filename := skylarktest.DataFile("skylark/syntax", "testdata/errors.sky")
 	for _, chunk := range chunkedfile.Read(filename, t) {
-		_, err := syntax.Parse(filename, chunk.Source)
+		_, err := syntax.Parse(filename, chunk.Source, 0)
 		switch err := err.(type) {
 		case nil:
 			// ok
@@ -355,7 +361,7 @@ for x in y:
 	// (compare against a reflect-based implementation).
 	// TODO(adonovan): test that the result of f is used to prune
 	// the descent.
-	f, err := syntax.Parse("hello.go", src)
+	f, err := syntax.Parse("hello.go", src, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -291,7 +291,7 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 				continue // skip positions
 			}
 			name := x.Type().Field(i).Name
-			if name == "CommentsRef" {
+			if name == "commentsRef" {
 				continue // skip comments fields
 			}
 			if f.Type() == reflect.TypeOf(syntax.Token(0)) {

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -258,7 +258,6 @@ func stripPos(err error) string {
 func treeString(n syntax.Node) string {
 	var buf bytes.Buffer
 	writeTree(&buf, reflect.ValueOf(n))
-	// Skip comments fields
 	return buf.String()
 }
 

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -292,8 +292,7 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 				continue // skip positions
 			}
 			name := x.Type().Field(i).Name
-			//strings.Replace(, " Comments=(Comments)", "", -1)
-			if name == "Comments" {
+			if name == "CommentsRef" {
 				continue // skip comments fields
 			}
 			if f.Type() == reflect.TypeOf(syntax.Token(0)) {

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -213,7 +213,7 @@ type scanner struct {
 	indentstk    []int     // stack of indentation levels
 	dents        int       // number of saved INDENT (>0) or OUTDENT (<0) tokens to return
 	lineStart    bool      // after NEWLINE; convert spaces to indentation tokens
-	keepComments bool      // if false, do not return comments tokens
+	keepComments bool      // /accumulate comments in slice
 	comments     []Comment // list of comments seen in the file (if keepComments was true)
 }
 
@@ -452,7 +452,6 @@ start:
 	if sc.dents != 0 {
 		sc.startToken(val)
 		sc.endToken(val)
-		blank = false
 		if sc.dents < 0 {
 			sc.dents++
 			return OUTDENT
@@ -494,14 +493,12 @@ start:
 		if blank || sc.depth > 0 {
 			// Ignore blank lines, or newlines within expressions (common case).
 			sc.readRune()
-			blank = false
 			goto start
 		}
 		// At top-level (not in an expression).
 		sc.startToken(val)
 		sc.readRune()
 		val.raw = "\n"
-		blank = false
 		return NEWLINE
 	}
 

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -213,9 +213,9 @@ type scanner struct {
 	indentstk      []int     // stack of indentation levels
 	dents          int       // number of saved INDENT (>0) or OUTDENT (<0) tokens to return
 	lineStart      bool      // after NEWLINE; convert spaces to indentation tokens
-	keepComments   bool      // /accumulate comments in slice
-	lineComments   []Comment // list of full line comments (if keepComments was true)
-	suffixComments []Comment // list of suffix comments (if keepComments was true)
+	keepComments   bool      // accumulate comments in slice
+	lineComments   []Comment // list of full line comments (if keepComments)
+	suffixComments []Comment // list of suffix comments (if keepComments)
 }
 
 func newScanner(filename string, src interface{}, keepComments bool) (*scanner, error) {

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -200,11 +200,11 @@ func (p Position) String() string {
 	return fmt.Sprintf("%s:%d:%d", p.Filename(), p.Line, p.Col)
 }
 
-func (p Position) IsBefore(p2 Position) bool {
-	if p.Line != p2.Line {
-		return p.Line < p2.Line
+func (p Position) isBefore(q Position) bool {
+	if p.Line != q.Line {
+		return p.Line < q.Line
 	}
-	return p.Col < p2.Col
+	return p.Col < q.Col
 }
 
 // An scanner represents a single input file being parsed.

--- a/syntax/scan.go
+++ b/syntax/scan.go
@@ -476,7 +476,7 @@ start:
 
 	// comment
 	if c == '#' {
-		if keepComments {
+		if sc.keepComments {
 			sc.startToken(val)
 		}
 		// Consume up to newline (included).
@@ -484,7 +484,7 @@ start:
 			sc.readRune()
 			c = sc.peekRune()
 		}
-		if keepComments {
+		if sc.keepComments {
 			sc.endToken(val)
 			if sc.blank {
 				return LINE_COMMENT

--- a/syntax/scan_test.go
+++ b/syntax/scan_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func scan(src interface{}) (tokens string, err error) {
-	sc, err := newScanner("foo.sky", src)
+	sc, err := newScanner("foo.sky", src, false)
 	if err != nil {
 		return "", err
 	}
@@ -233,7 +233,7 @@ func BenchmarkScan(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		sc, err := newScanner(filename, data)
+		sc, err := newScanner(filename, data, false)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -17,7 +17,7 @@ type Node interface {
 type Comment struct {
 	Start  Position
 	Token  string // without trailing newline
-	Suffix bool   // an end of line (not whole line) comment
+	Suffix bool   // an end-of-line (not whole line) comment
 }
 
 // Comments collects the comments associated with an expression.
@@ -52,7 +52,7 @@ func End(n Node) Position {
 
 // A File represents a Skylark file.
 type File struct {
-	Comments
+	*Comments
 	Path  string
 	Stmts []Stmt
 
@@ -89,7 +89,7 @@ func (*ReturnStmt) stmt() {}
 //	x, y = y, x
 // 	x += 1
 type AssignStmt struct {
-	Comments
+	*Comments
 	OpPos Position
 	Op    Token // = EQ | {PLUS,MINUS,STAR,PERCENT}_EQ
 	LHS   Expr
@@ -104,7 +104,7 @@ func (x *AssignStmt) Span() (start, end Position) {
 
 // A Function represents the common parts of LambdaExpr and DefStmt.
 type Function struct {
-	Comments
+	*Comments
 	StartPos Position // position of DEF or LAMBDA token
 	Params   []Expr   // param = ident | ident=expr | *ident | **ident
 	Body     []Stmt
@@ -123,7 +123,7 @@ func (x *Function) Span() (start, end Position) {
 
 // A DefStmt represents a function definition.
 type DefStmt struct {
-	Comments
+	*Comments
 	Def  Position
 	Name *Ident
 	Function
@@ -136,7 +136,7 @@ func (x *DefStmt) Span() (start, end Position) {
 
 // An ExprStmt is an expression evaluated for side effects.
 type ExprStmt struct {
-	Comments
+	*Comments
 	X Expr
 }
 
@@ -147,7 +147,7 @@ func (x *ExprStmt) Span() (start, end Position) {
 // An IfStmt is a conditional: If Cond: True; else: False.
 // 'elseif' is desugared into a chain of IfStmts.
 type IfStmt struct {
-	Comments
+	*Comments
 	If      Position // IF or ELIF
 	Cond    Expr
 	True    []Stmt
@@ -173,7 +173,7 @@ func (x *IfStmt) Span() (start, end Position) {
 // without.  For consistency we create fake identifiers for all the
 // strings.
 type LoadStmt struct {
-	Comments
+	*Comments
 	Load   Position
 	Module *Literal // a string
 	From   []*Ident // name defined in loading module
@@ -187,7 +187,7 @@ func (x *LoadStmt) Span() (start, end Position) {
 
 // A BranchStmt changes the flow of control: break, continue, pass.
 type BranchStmt struct {
-	Comments
+	*Comments
 	Token    Token // = BREAK | CONTINUE | PASS
 	TokenPos Position
 }
@@ -198,7 +198,7 @@ func (x *BranchStmt) Span() (start, end Position) {
 
 // A ReturnStmt returns from a function.
 type ReturnStmt struct {
-	Comments
+	*Comments
 	Return Position
 	Result Expr // may be nil
 }
@@ -235,7 +235,7 @@ func (*UnaryExpr) expr()     {}
 
 // An Ident represents an identifier.
 type Ident struct {
-	Comments
+	*Comments
 	NamePos Position
 	Name    string
 
@@ -251,7 +251,7 @@ func (x *Ident) Span() (start, end Position) {
 
 // A Literal represents a literal string or number.
 type Literal struct {
-	Comments
+	*Comments
 	Token    Token // = STRING | INT
 	TokenPos Position
 	Raw      string      // uninterpreted text
@@ -264,7 +264,7 @@ func (x *Literal) Span() (start, end Position) {
 
 // A CallExpr represents a function call expression: Fn(Args).
 type CallExpr struct {
-	Comments
+	*Comments
 	Fn     Expr
 	Lparen Position
 	Args   []Expr
@@ -278,7 +278,7 @@ func (x *CallExpr) Span() (start, end Position) {
 
 // A DotExpr represents a field or method selector: X.Name.
 type DotExpr struct {
-	Comments
+	*Comments
 	X       Expr
 	Dot     Position
 	NamePos Position
@@ -294,7 +294,7 @@ func (x *DotExpr) Span() (start, end Position) {
 // A Comprehension represents a list or dict comprehension:
 // [Body for ... if ...] or {Body for ... if ...}
 type Comprehension struct {
-	Comments
+	*Comments
 	Curly   bool // {x:y for ...} or {x for ...}, not [x for ...]
 	Lbrack  Position
 	Body    Expr
@@ -308,7 +308,7 @@ func (x *Comprehension) Span() (start, end Position) {
 
 // A ForStmt represents a loop: for Vars in X: Body.
 type ForStmt struct {
-	Comments
+	*Comments
 	For  Position
 	Vars Expr // name, or tuple of names
 	X    Expr
@@ -322,7 +322,7 @@ func (x *ForStmt) Span() (start, end Position) {
 
 // A ForClause represents a for clause in a list comprehension: for Vars in X.
 type ForClause struct {
-	Comments
+	*Comments
 	For  Position
 	Vars Expr // name, or tuple of names
 	In   Position
@@ -336,7 +336,7 @@ func (x *ForClause) Span() (start, end Position) {
 
 // An IfClause represents an if clause in a list comprehension: if Cond.
 type IfClause struct {
-	Comments
+	*Comments
 	If   Position
 	Cond Expr
 }
@@ -348,7 +348,7 @@ func (x *IfClause) Span() (start, end Position) {
 
 // A DictExpr represents a dictionary literal: { List }.
 type DictExpr struct {
-	Comments
+	*Comments
 	Lbrace Position
 	List   []Expr // all *DictEntrys
 	Rbrace Position
@@ -361,7 +361,7 @@ func (x *DictExpr) Span() (start, end Position) {
 // A DictEntry represents a dictionary entry: Key: Value.
 // Used only within a DictExpr.
 type DictEntry struct {
-	Comments
+	*Comments
 	Key   Expr
 	Colon Position
 	Value Expr
@@ -379,7 +379,7 @@ func (x *DictEntry) Span() (start, end Position) {
 // currently part of the Skylark spec, so their use is controlled by the
 // resolver.AllowLambda flag.
 type LambdaExpr struct {
-	Comments
+	*Comments
 	Lambda Position
 	Function
 }
@@ -391,7 +391,7 @@ func (x *LambdaExpr) Span() (start, end Position) {
 
 // A ListExpr represents a list literal: [ List ].
 type ListExpr struct {
-	Comments
+	*Comments
 	Lbrack Position
 	List   []Expr
 	Rbrack Position
@@ -403,7 +403,7 @@ func (x *ListExpr) Span() (start, end Position) {
 
 // CondExpr represents the conditional: X if COND else ELSE.
 type CondExpr struct {
-	Comments
+	*Comments
 	If      Position
 	Cond    Expr
 	True    Expr
@@ -419,7 +419,7 @@ func (x *CondExpr) Span() (start, end Position) {
 
 // A TupleExpr represents a tuple literal: (List).
 type TupleExpr struct {
-	Comments
+	*Comments
 	Lparen Position // optional (e.g. in x, y = 0, 1), but required if List is empty
 	List   []Expr
 	Rparen Position
@@ -435,7 +435,7 @@ func (x *TupleExpr) Span() (start, end Position) {
 
 // A UnaryExpr represents a unary expression: Op X.
 type UnaryExpr struct {
-	Comments
+	*Comments
 	OpPos Position
 	Op    Token
 	X     Expr
@@ -448,7 +448,7 @@ func (x *UnaryExpr) Span() (start, end Position) {
 
 // A BinaryExpr represents a binary expression: X Op Y.
 type BinaryExpr struct {
-	Comments
+	*Comments
 	X     Expr
 	OpPos Position
 	Op    Token
@@ -463,7 +463,7 @@ func (x *BinaryExpr) Span() (start, end Position) {
 
 // A SliceExpr represents a slice or substring expression: X[Lo:Hi:Step].
 type SliceExpr struct {
-	Comments
+	*Comments
 	X            Expr
 	Lbrack       Position
 	Lo, Hi, Step Expr // all optional
@@ -477,7 +477,7 @@ func (x *SliceExpr) Span() (start, end Position) {
 
 // An IndexExpr represents an index expression: X[Y].
 type IndexExpr struct {
-	Comments
+	*Comments
 	X      Expr
 	Lbrack Position
 	Y      Expr

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -22,9 +22,8 @@ type Node interface {
 
 // A Comment represents a single # comment.
 type Comment struct {
-	Start  Position
-	Text   string // without trailing newline
-	Suffix bool   // an end-of-line (not whole line) comment
+	Start Position
+	Text  string // without trailing newline
 }
 
 // Comments collects the comments associated with an expression.
@@ -37,17 +36,17 @@ type Comments struct {
 	After []Comment
 }
 
-// A CommentsRef is a possibly-nil reference to a set of comments.
-// A CommentsRef is embedded in each type of syntax node,
+// A commentsRef is a possibly-nil reference to a set of comments.
+// A commentsRef is embedded in each type of syntax node,
 // and provides its Comments and AllocComments methods.
-type CommentsRef struct{ ref *Comments }
+type commentsRef struct{ ref *Comments }
 
 // Comments returns the comments associated with a syntax node,
 // or nil if AllocComments has not yet been called.
-func (cr CommentsRef) Comments() *Comments { return cr.ref }
+func (cr commentsRef) Comments() *Comments { return cr.ref }
 
 // AllocComments enables comments to be associated with a syntax node.
-func (cr *CommentsRef) AllocComments() {
+func (cr *commentsRef) AllocComments() {
 	if cr.ref == nil {
 		cr.ref = new(Comments)
 	}
@@ -67,7 +66,7 @@ func End(n Node) Position {
 
 // A File represents a Skylark file.
 type File struct {
-	CommentsRef
+	commentsRef
 	Path  string
 	Stmts []Stmt
 
@@ -104,7 +103,7 @@ func (*ReturnStmt) stmt() {}
 //	x, y = y, x
 // 	x += 1
 type AssignStmt struct {
-	CommentsRef
+	commentsRef
 	OpPos Position
 	Op    Token // = EQ | {PLUS,MINUS,STAR,PERCENT}_EQ
 	LHS   Expr
@@ -119,7 +118,7 @@ func (x *AssignStmt) Span() (start, end Position) {
 
 // A Function represents the common parts of LambdaExpr and DefStmt.
 type Function struct {
-	CommentsRef
+	commentsRef
 	StartPos Position // position of DEF or LAMBDA token
 	Params   []Expr   // param = ident | ident=expr | *ident | **ident
 	Body     []Stmt
@@ -138,7 +137,7 @@ func (x *Function) Span() (start, end Position) {
 
 // A DefStmt represents a function definition.
 type DefStmt struct {
-	CommentsRef
+	commentsRef
 	Def  Position
 	Name *Ident
 	Function
@@ -151,7 +150,7 @@ func (x *DefStmt) Span() (start, end Position) {
 
 // An ExprStmt is an expression evaluated for side effects.
 type ExprStmt struct {
-	CommentsRef
+	commentsRef
 	X Expr
 }
 
@@ -162,7 +161,7 @@ func (x *ExprStmt) Span() (start, end Position) {
 // An IfStmt is a conditional: If Cond: True; else: False.
 // 'elseif' is desugared into a chain of IfStmts.
 type IfStmt struct {
-	CommentsRef
+	commentsRef
 	If      Position // IF or ELIF
 	Cond    Expr
 	True    []Stmt
@@ -188,7 +187,7 @@ func (x *IfStmt) Span() (start, end Position) {
 // without.  For consistency we create fake identifiers for all the
 // strings.
 type LoadStmt struct {
-	CommentsRef
+	commentsRef
 	Load   Position
 	Module *Literal // a string
 	From   []*Ident // name defined in loading module
@@ -202,7 +201,7 @@ func (x *LoadStmt) Span() (start, end Position) {
 
 // A BranchStmt changes the flow of control: break, continue, pass.
 type BranchStmt struct {
-	CommentsRef
+	commentsRef
 	Token    Token // = BREAK | CONTINUE | PASS
 	TokenPos Position
 }
@@ -213,7 +212,7 @@ func (x *BranchStmt) Span() (start, end Position) {
 
 // A ReturnStmt returns from a function.
 type ReturnStmt struct {
-	CommentsRef
+	commentsRef
 	Return Position
 	Result Expr // may be nil
 }
@@ -250,7 +249,7 @@ func (*UnaryExpr) expr()     {}
 
 // An Ident represents an identifier.
 type Ident struct {
-	CommentsRef
+	commentsRef
 	NamePos Position
 	Name    string
 
@@ -266,7 +265,7 @@ func (x *Ident) Span() (start, end Position) {
 
 // A Literal represents a literal string or number.
 type Literal struct {
-	CommentsRef
+	commentsRef
 	Token    Token // = STRING | INT
 	TokenPos Position
 	Raw      string      // uninterpreted text
@@ -279,7 +278,7 @@ func (x *Literal) Span() (start, end Position) {
 
 // A CallExpr represents a function call expression: Fn(Args).
 type CallExpr struct {
-	CommentsRef
+	commentsRef
 	Fn     Expr
 	Lparen Position
 	Args   []Expr
@@ -293,7 +292,7 @@ func (x *CallExpr) Span() (start, end Position) {
 
 // A DotExpr represents a field or method selector: X.Name.
 type DotExpr struct {
-	CommentsRef
+	commentsRef
 	X       Expr
 	Dot     Position
 	NamePos Position
@@ -309,7 +308,7 @@ func (x *DotExpr) Span() (start, end Position) {
 // A Comprehension represents a list or dict comprehension:
 // [Body for ... if ...] or {Body for ... if ...}
 type Comprehension struct {
-	CommentsRef
+	commentsRef
 	Curly   bool // {x:y for ...} or {x for ...}, not [x for ...]
 	Lbrack  Position
 	Body    Expr
@@ -323,7 +322,7 @@ func (x *Comprehension) Span() (start, end Position) {
 
 // A ForStmt represents a loop: for Vars in X: Body.
 type ForStmt struct {
-	CommentsRef
+	commentsRef
 	For  Position
 	Vars Expr // name, or tuple of names
 	X    Expr
@@ -337,7 +336,7 @@ func (x *ForStmt) Span() (start, end Position) {
 
 // A ForClause represents a for clause in a list comprehension: for Vars in X.
 type ForClause struct {
-	CommentsRef
+	commentsRef
 	For  Position
 	Vars Expr // name, or tuple of names
 	In   Position
@@ -351,7 +350,7 @@ func (x *ForClause) Span() (start, end Position) {
 
 // An IfClause represents an if clause in a list comprehension: if Cond.
 type IfClause struct {
-	CommentsRef
+	commentsRef
 	If   Position
 	Cond Expr
 }
@@ -363,7 +362,7 @@ func (x *IfClause) Span() (start, end Position) {
 
 // A DictExpr represents a dictionary literal: { List }.
 type DictExpr struct {
-	CommentsRef
+	commentsRef
 	Lbrace Position
 	List   []Expr // all *DictEntrys
 	Rbrace Position
@@ -376,7 +375,7 @@ func (x *DictExpr) Span() (start, end Position) {
 // A DictEntry represents a dictionary entry: Key: Value.
 // Used only within a DictExpr.
 type DictEntry struct {
-	CommentsRef
+	commentsRef
 	Key   Expr
 	Colon Position
 	Value Expr
@@ -394,7 +393,7 @@ func (x *DictEntry) Span() (start, end Position) {
 // currently part of the Skylark spec, so their use is controlled by the
 // resolver.AllowLambda flag.
 type LambdaExpr struct {
-	CommentsRef
+	commentsRef
 	Lambda Position
 	Function
 }
@@ -406,7 +405,7 @@ func (x *LambdaExpr) Span() (start, end Position) {
 
 // A ListExpr represents a list literal: [ List ].
 type ListExpr struct {
-	CommentsRef
+	commentsRef
 	Lbrack Position
 	List   []Expr
 	Rbrack Position
@@ -418,7 +417,7 @@ func (x *ListExpr) Span() (start, end Position) {
 
 // CondExpr represents the conditional: X if COND else ELSE.
 type CondExpr struct {
-	CommentsRef
+	commentsRef
 	If      Position
 	Cond    Expr
 	True    Expr
@@ -434,7 +433,7 @@ func (x *CondExpr) Span() (start, end Position) {
 
 // A TupleExpr represents a tuple literal: (List).
 type TupleExpr struct {
-	CommentsRef
+	commentsRef
 	Lparen Position // optional (e.g. in x, y = 0, 1), but required if List is empty
 	List   []Expr
 	Rparen Position
@@ -450,7 +449,7 @@ func (x *TupleExpr) Span() (start, end Position) {
 
 // A UnaryExpr represents a unary expression: Op X.
 type UnaryExpr struct {
-	CommentsRef
+	commentsRef
 	OpPos Position
 	Op    Token
 	X     Expr
@@ -463,7 +462,7 @@ func (x *UnaryExpr) Span() (start, end Position) {
 
 // A BinaryExpr represents a binary expression: X Op Y.
 type BinaryExpr struct {
-	CommentsRef
+	commentsRef
 	X     Expr
 	OpPos Position
 	Op    Token
@@ -478,7 +477,7 @@ func (x *BinaryExpr) Span() (start, end Position) {
 
 // A SliceExpr represents a slice or substring expression: X[Lo:Hi:Step].
 type SliceExpr struct {
-	CommentsRef
+	commentsRef
 	X            Expr
 	Lbrack       Position
 	Lo, Hi, Step Expr // all optional
@@ -492,7 +491,7 @@ func (x *SliceExpr) Span() (start, end Position) {
 
 // An IndexExpr represents an index expression: X[Y].
 type IndexExpr struct {
-	CommentsRef
+	commentsRef
 	X      Expr
 	Lbrack Position
 	Y      Expr

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -29,7 +29,7 @@ type Comment struct {
 // Comments collects the comments associated with an expression.
 type Comments struct {
 	Before []Comment // whole-line comments before this expression
-	Suffix []Comment // end-of-line comments after this expression
+	Suffix []Comment // end-of-line comments after this expression (up to 1)
 
 	// For top-level expressions only, After lists whole-line
 	// comments following the expression.

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -16,7 +16,7 @@ type Node interface {
 // A Comment represents a single # comment.
 type Comment struct {
 	Start  Position
-	Token  string // without trailing newline
+	Text   string // without trailing newline
 	Suffix bool   // an end-of-line (not whole line) comment
 }
 

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -10,8 +10,13 @@ type Node interface {
 	// Span returns the start and end position of the expression.
 	Span() (start, end Position)
 
-	AllocComments()
+	// Comments returns the comments associated with this node.
+	// It returns nil if RetainComments was not specified during parsing.
 	Comments() *Comments
+
+	// AllocComments allocates a new Comments node if there was none.
+	// This makes possible to add new comments using Comments() method.
+	AllocComments()
 }
 
 // A Comment represents a single # comment.

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -9,6 +9,33 @@ package syntax
 type Node interface {
 	// Span returns the start and end position of the expression.
 	Span() (start, end Position)
+
+	Comment() *Comments
+}
+
+// A Comment represents a single # comment.
+type Comment struct {
+	Start  Position
+	Token  string // without trailing newline
+	Suffix bool   // an end of line (not whole line) comment
+}
+
+// Comments collects the comments associated with an expression.
+type Comments struct {
+	Before []Comment // whole-line comments before this expression
+	Suffix []Comment // end-of-line comments after this expression
+
+	// For top-level expressions only, After lists whole-line
+	// comments following the expression.
+	After []Comment
+}
+
+// Comment returns the receiver. This isn't useful by itself, but
+// a Comments struct is embedded into all the expression
+// implementation types, and this gives each of those a Comment
+// method to satisfy the Expr interface.
+func (c *Comments) Comment() *Comments {
+	return c
 }
 
 // Start returns the start position of the expression.
@@ -25,6 +52,7 @@ func End(n Node) Position {
 
 // A File represents a Skylark file.
 type File struct {
+	Comments
 	Path  string
 	Stmts []Stmt
 
@@ -61,6 +89,7 @@ func (*ReturnStmt) stmt() {}
 //	x, y = y, x
 // 	x += 1
 type AssignStmt struct {
+	Comments
 	OpPos Position
 	Op    Token // = EQ | {PLUS,MINUS,STAR,PERCENT}_EQ
 	LHS   Expr
@@ -75,6 +104,7 @@ func (x *AssignStmt) Span() (start, end Position) {
 
 // A Function represents the common parts of LambdaExpr and DefStmt.
 type Function struct {
+	Comments
 	StartPos Position // position of DEF or LAMBDA token
 	Params   []Expr   // param = ident | ident=expr | *ident | **ident
 	Body     []Stmt
@@ -93,6 +123,7 @@ func (x *Function) Span() (start, end Position) {
 
 // A DefStmt represents a function definition.
 type DefStmt struct {
+	Comments
 	Def  Position
 	Name *Ident
 	Function
@@ -105,6 +136,7 @@ func (x *DefStmt) Span() (start, end Position) {
 
 // An ExprStmt is an expression evaluated for side effects.
 type ExprStmt struct {
+	Comments
 	X Expr
 }
 
@@ -115,6 +147,7 @@ func (x *ExprStmt) Span() (start, end Position) {
 // An IfStmt is a conditional: If Cond: True; else: False.
 // 'elseif' is desugared into a chain of IfStmts.
 type IfStmt struct {
+	Comments
 	If      Position // IF or ELIF
 	Cond    Expr
 	True    []Stmt
@@ -140,6 +173,7 @@ func (x *IfStmt) Span() (start, end Position) {
 // without.  For consistency we create fake identifiers for all the
 // strings.
 type LoadStmt struct {
+	Comments
 	Load   Position
 	Module *Literal // a string
 	From   []*Ident // name defined in loading module
@@ -153,6 +187,7 @@ func (x *LoadStmt) Span() (start, end Position) {
 
 // A BranchStmt changes the flow of control: break, continue, pass.
 type BranchStmt struct {
+	Comments
 	Token    Token // = BREAK | CONTINUE | PASS
 	TokenPos Position
 }
@@ -163,6 +198,7 @@ func (x *BranchStmt) Span() (start, end Position) {
 
 // A ReturnStmt returns from a function.
 type ReturnStmt struct {
+	Comments
 	Return Position
 	Result Expr // may be nil
 }
@@ -199,6 +235,7 @@ func (*UnaryExpr) expr()     {}
 
 // An Ident represents an identifier.
 type Ident struct {
+	Comments
 	NamePos Position
 	Name    string
 
@@ -214,6 +251,7 @@ func (x *Ident) Span() (start, end Position) {
 
 // A Literal represents a literal string or number.
 type Literal struct {
+	Comments
 	Token    Token // = STRING | INT
 	TokenPos Position
 	Raw      string      // uninterpreted text
@@ -226,6 +264,7 @@ func (x *Literal) Span() (start, end Position) {
 
 // A CallExpr represents a function call expression: Fn(Args).
 type CallExpr struct {
+	Comments
 	Fn     Expr
 	Lparen Position
 	Args   []Expr
@@ -239,6 +278,7 @@ func (x *CallExpr) Span() (start, end Position) {
 
 // A DotExpr represents a field or method selector: X.Name.
 type DotExpr struct {
+	Comments
 	X       Expr
 	Dot     Position
 	NamePos Position
@@ -254,6 +294,7 @@ func (x *DotExpr) Span() (start, end Position) {
 // A Comprehension represents a list or dict comprehension:
 // [Body for ... if ...] or {Body for ... if ...}
 type Comprehension struct {
+	Comments
 	Curly   bool // {x:y for ...} or {x for ...}, not [x for ...]
 	Lbrack  Position
 	Body    Expr
@@ -267,6 +308,7 @@ func (x *Comprehension) Span() (start, end Position) {
 
 // A ForStmt represents a loop: for Vars in X: Body.
 type ForStmt struct {
+	Comments
 	For  Position
 	Vars Expr // name, or tuple of names
 	X    Expr
@@ -280,6 +322,7 @@ func (x *ForStmt) Span() (start, end Position) {
 
 // A ForClause represents a for clause in a list comprehension: for Vars in X.
 type ForClause struct {
+	Comments
 	For  Position
 	Vars Expr // name, or tuple of names
 	In   Position
@@ -293,6 +336,7 @@ func (x *ForClause) Span() (start, end Position) {
 
 // An IfClause represents an if clause in a list comprehension: if Cond.
 type IfClause struct {
+	Comments
 	If   Position
 	Cond Expr
 }
@@ -304,6 +348,7 @@ func (x *IfClause) Span() (start, end Position) {
 
 // A DictExpr represents a dictionary literal: { List }.
 type DictExpr struct {
+	Comments
 	Lbrace Position
 	List   []Expr // all *DictEntrys
 	Rbrace Position
@@ -316,6 +361,7 @@ func (x *DictExpr) Span() (start, end Position) {
 // A DictEntry represents a dictionary entry: Key: Value.
 // Used only within a DictExpr.
 type DictEntry struct {
+	Comments
 	Key   Expr
 	Colon Position
 	Value Expr
@@ -333,6 +379,7 @@ func (x *DictEntry) Span() (start, end Position) {
 // currently part of the Skylark spec, so their use is controlled by the
 // resolver.AllowLambda flag.
 type LambdaExpr struct {
+	Comments
 	Lambda Position
 	Function
 }
@@ -344,6 +391,7 @@ func (x *LambdaExpr) Span() (start, end Position) {
 
 // A ListExpr represents a list literal: [ List ].
 type ListExpr struct {
+	Comments
 	Lbrack Position
 	List   []Expr
 	Rbrack Position
@@ -355,6 +403,7 @@ func (x *ListExpr) Span() (start, end Position) {
 
 // CondExpr represents the conditional: X if COND else ELSE.
 type CondExpr struct {
+	Comments
 	If      Position
 	Cond    Expr
 	True    Expr
@@ -370,6 +419,7 @@ func (x *CondExpr) Span() (start, end Position) {
 
 // A TupleExpr represents a tuple literal: (List).
 type TupleExpr struct {
+	Comments
 	Lparen Position // optional (e.g. in x, y = 0, 1), but required if List is empty
 	List   []Expr
 	Rparen Position
@@ -385,6 +435,7 @@ func (x *TupleExpr) Span() (start, end Position) {
 
 // A UnaryExpr represents a unary expression: Op X.
 type UnaryExpr struct {
+	Comments
 	OpPos Position
 	Op    Token
 	X     Expr
@@ -397,6 +448,7 @@ func (x *UnaryExpr) Span() (start, end Position) {
 
 // A BinaryExpr represents a binary expression: X Op Y.
 type BinaryExpr struct {
+	Comments
 	X     Expr
 	OpPos Position
 	Op    Token
@@ -411,6 +463,7 @@ func (x *BinaryExpr) Span() (start, end Position) {
 
 // A SliceExpr represents a slice or substring expression: X[Lo:Hi:Step].
 type SliceExpr struct {
+	Comments
 	X            Expr
 	Lbrack       Position
 	Lo, Hi, Step Expr // all optional
@@ -424,6 +477,7 @@ func (x *SliceExpr) Span() (start, end Position) {
 
 // An IndexExpr represents an index expression: X[Y].
 type IndexExpr struct {
+	Comments
 	X      Expr
 	Lbrack Position
 	Y      Expr

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -11,7 +11,8 @@ type Node interface {
 	Span() (start, end Position)
 
 	// Comments returns the comments associated with this node.
-	// It returns nil if RetainComments was not specified during parsing.
+	// It returns nil if RetainComments was not specified during parsing,
+	// or if AllocComments was not called.
 	Comments() *Comments
 
 	// AllocComments allocates a new Comments node if there was none.


### PR DESCRIPTION
This feature is off by default. More testing will be needed before
exposing it to the ParseFile function.

Logic is copied from Buildifier (https://github.com/bazelbuild/buildtools/tree/master/build).

bug #63