### PR TITLE
skylarkstruct: several fixes

### DIFF
--- a/library.go
+++ b/library.go
@@ -531,8 +531,19 @@ func hasattr(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, err
 		return nil, err
 	}
 	if object, ok := object.(HasAttrs); ok {
-		if v, err := object.Attr(name); v != nil || err != nil {
-			return True, nil
+		v, err := object.Attr(name)
+		if err == nil {
+			return Bool(v != nil), nil
+		}
+
+		// An error does not conclusively indicate presence or
+		// absence of a field: it could occur while computing
+		// the value of a present attribute, or it could be a
+		// "no such attribute" error with details.
+		for _, x := range object.AttrNames() {
+			if x == name {
+				return True, nil
+			}
 		}
 	}
 	return False, nil

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package skylarkstruct_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/skylark"
+	"github.com/google/skylark/resolve"
+	"github.com/google/skylark/skylarkstruct"
+	"github.com/google/skylark/skylarktest"
+)
+
+func init() {
+	// The tests make extensive use of these not-yet-standard features.
+	resolve.AllowLambda = true
+	resolve.AllowNestedDef = true
+	resolve.AllowFloat = true
+	resolve.AllowSet = true
+}
+
+func Test(t *testing.T) {
+	testdata := skylarktest.DataFile("skylark/skylarkstruct", ".")
+	thread := &skylark.Thread{Load: load}
+	skylarktest.SetReporter(thread, t)
+	filename := filepath.Join(testdata, "testdata/struct.sky")
+	globals := skylark.StringDict{
+		"struct": skylark.NewBuiltin("struct", skylarkstruct.Make),
+		"gensym": skylark.NewBuiltin("gensym", gensym),
+	}
+	if err := skylark.ExecFile(thread, filename, nil, globals); err != nil {
+		if err, ok := err.(*skylark.EvalError); ok {
+			t.Fatal(err.Backtrace())
+		}
+		t.Fatal(err)
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func load(thread *skylark.Thread, module string) (skylark.StringDict, error) {
+	if module == "assert.sky" {
+		return skylarktest.LoadAssertModule()
+	}
+	return nil, fmt.Errorf("load not implemented")
+}
+
+// gensym is a built-in function that generates a unique symbol.
+func gensym(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var name string
+	if err := skylark.UnpackArgs("gensym", args, kwargs, "name", &name); err != nil {
+		return nil, err
+	}
+	return &symbol{name: name}, nil
+}
+
+// A symbol is a distinct value that acts as a constructor of "branded"
+// struct instances, like a class symbol in Python or a "provider" in Bazel.
+type symbol struct{ name string }
+
+var _ skylark.Callable = (*symbol)(nil)
+
+func (sym *symbol) Name() string          { return sym.name }
+func (sym *symbol) String() string        { return sym.name }
+func (sym *symbol) Type() string          { return "symbol" }
+func (sym *symbol) Freeze()               {} // immutable
+func (sym *symbol) Truth() skylark.Bool   { return skylark.True }
+func (sym *symbol) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", sym.Type()) }
+
+func (sym *symbol) Call(thread *skylark.Thread, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	if len(args) > 0 {
+		return nil, fmt.Errorf("%s: unexpected positional arguments", sym)
+	}
+	return skylarkstruct.FromKeywords(sym, kwargs), nil
+}

--- a/skylarkstruct/testdata/struct.sky
+++ b/skylarkstruct/testdata/struct.sky
@@ -1,0 +1,72 @@
+# Tests of Skylark 'struct' extension.
+# This is not a standard feature and the Go and Skylark APIs may yet change.
+
+load('assert.sky', 'assert')
+
+assert.eq(str(struct), '<built-in function struct>')
+
+# struct is a constructor for "unbranded" structs.
+s = struct(host='localhost', port=80)
+assert.eq(s, s)
+assert.eq(s, struct(host='localhost', port=80))
+assert.ne(s, struct(host='localhost', port=81))
+assert.eq(type(s), 'struct')
+assert.eq(str(s),  'struct(host = "localhost", port = 80)')
+assert.eq(s.host, 'localhost')
+assert.eq(s.port, 80)
+assert.fails(lambda: s.protocol, 'struct has no .protocol attribute')
+assert.eq(dir(s), ['host', 'port'])
+
+# Use gensym to create "branded" struct types.
+hostport = gensym(name='hostport')
+assert.eq(type(hostport), 'symbol')
+assert.eq(str(hostport), 'hostport')
+
+# Call the symbol to instantiate a new type.
+http = hostport(host='localhost', port=80)
+assert.eq(type(http), 'struct')
+assert.eq(str(http), 'hostport(host = "localhost", port = 80)') # includes name of constructor
+assert.eq(http, http)
+assert.eq(http, hostport(host='localhost', port=80))
+assert.ne(http, hostport(host='localhost', port=443))
+assert.eq(http.host, 'localhost')
+assert.eq(http.port, 80)
+assert.fails(lambda: http.protocol, 'hostport struct has no .protocol attribute')
+
+person = gensym(name='person')
+bob = person(name='bob', age=50)
+alice = person(name='alice', city='NYC')
+assert.ne(http, bob)  # different constructor symbols
+assert.ne(bob, alice) # different fields
+
+hostport2 = gensym(name='hostport')
+assert.eq(hostport, hostport)
+assert.ne(hostport, hostport2) # same name, different symbol
+assert.ne(http, hostport2(host='localhost', port=80)) # equal fields but different ctor symbols
+
+# dir
+assert.eq(dir(alice), ['city', 'name'])
+assert.eq(dir(bob), ['age', 'name'])
+assert.eq(dir(http), ['host', 'port'])
+
+# hasattr, getattr
+assert.true(hasattr(alice, 'city'))
+assert.eq(hasattr(alice, 'ageaa'), False)
+assert.eq(getattr(alice, 'city'), 'NYC')
+
+# +
+assert.eq(bob + bob, bob)
+assert.eq(bob + alice, person(age=50, city='NYC', name='alice'))
+assert.eq(alice + bob, person(age=50, city='NYC', name='bob'))  # not commutative! a misfeature
+assert.fails(lambda: alice + 1, r'struct \+ int')
+assert.eq(http + http, http)
+assert.fails(lambda: http + bob, r'different constructors: hostport \+ person')
+
+# to_json (deprecated)
+assert.eq(alice.to_json(), '{"city": "NYC", "name": "alice"}')
+assert.eq(bob.to_json(), '{"age": 50, "name": "bob"}')
+# These deprecated methods are hidden from dir:
+assert.eq(hasattr(alice, "to_json"), True)
+assert.eq(hasattr(bob, "to_proto"), True)
+# to_proto (deprecated, not implemented)
+assert.fails(lambda: bob.to_proto(), 'not yet implemented')


### PR DESCRIPTION
Details:
- hasattr: an error result from Attr does not reliably indicate that
  an attribute was missing. Fall back to checking AttrNames in that case.
- to_{json,proto}: propagate errors correctly.
- Include the constructor value (if nondefault) in the
  no-such-attribute error message. It is crucial for debugging.
- to_json: quote strings correctly.
- Added very basic tests of skylarkstruct, in Skylark.
