### PR TITLE
eval: allow 'list += x' where x is not iterable but defines list+x

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -186,7 +186,10 @@ type hasfields struct {
 	frozen bool
 }
 
-var _ skylark.HasAttrs = (*hasfields)(nil)
+var (
+	_ skylark.HasAttrs  = (*hasfields)(nil)
+	_ skylark.HasBinary = (*hasfields)(nil)
+)
 
 func (hf *hasfields) String() string        { return "hasfields" }
 func (hf *hasfields) Type() string          { return "hasfields" }
@@ -218,6 +221,17 @@ func (hf *hasfields) AttrNames() []string {
 		names = append(names, key)
 	}
 	return names
+}
+
+func (hf *hasfields) Binary(op syntax.Token, y skylark.Value, side skylark.Side) (skylark.Value, error) {
+	// This method exists so we can exercise 'list += x'
+	// where x is not Iterable but defines list+x.
+	if op == syntax.PLUS {
+		if _, ok := y.(*skylark.List); ok {
+			return skylark.MakeInt(42), nil // list+hasfields is 42
+		}
+	}
+	return nil, nil
 }
 
 func TestParameterPassing(t *testing.T) {

--- a/library.go
+++ b/library.go
@@ -321,11 +321,15 @@ func unpackOneArg(v Value, ptr interface{}) error {
 			return fmt.Errorf("got %s, want iterable", v.Type())
 		}
 	default:
-		param := reflect.ValueOf(ptr).Elem()
+		ptrv := reflect.ValueOf(ptr)
+		if ptrv.Kind() != reflect.Ptr {
+			log.Fatalf("internal error: not a pointer: %T", ptr)
+		}
+		param := ptrv.Elem()
 		if !reflect.TypeOf(v).AssignableTo(param.Type()) {
 			// Detect mistakes by caller.
 			if !param.Type().AssignableTo(reflect.TypeOf(new(Value)).Elem()) {
-				log.Fatalf("internal error: invalid ptr type: %T", ptr)
+				log.Fatalf("internal error: invalid pointer type: %T", ptr)
 			}
 			// Assume it's safe to call Type() on a zero instance.
 			paramType := param.Interface().(Value).Type()

--- a/testdata/list.sky
+++ b/testdata/list.sky
@@ -129,7 +129,7 @@ assert.fails(f4, "local variable a_list referenced before assignment")
 def f5():
   x = []
   x += 1
-assert.fails(f5, "invalid operation: list \\+= int")
+assert.fails(f5, "unknown binary op: list \\+ int")
 
 # frozen list += iterable
 def f6():
@@ -137,6 +137,13 @@ def f6():
   freeze(x)
   x += [1]
 assert.fails(f6, "cannot apply \\+= to frozen list")
+
+# list += hasfields (hasfields is not iterable but defines list+hasfields)
+def f7():
+  x = []
+  x += hasfields()
+  return x
+assert.eq(f7(), 42) # weird, but exercises a corner case in list+=x.
 
 # append
 x5 = [1, 2, 3]


### PR DESCRIPTION
This is the case for Bazel's depset
(although it really ought to be iterable).

Added regression test using hasfields, which is noniterable but
defines list+hasfields rather arbitraily.

Also: improve UnpackArgs failure when argument is a pointer.