### PR TITLE
str: print Go nil values gracefully

### DIFF
--- a/value.go
+++ b/value.go
@@ -828,6 +828,9 @@ func toString(v Value) string {
 // (These are the only potentially cyclic structures.)
 func writeValue(out *bytes.Buffer, x Value, path []Value) {
 	switch x := x.(type) {
+	case nil:
+		out.WriteString("<nil>") // indicates a bug
+
 	case NoneType:
 		out.WriteString("None")
 


### PR DESCRIPTION
Such values are not legal Skylark values,
but this change makes it easier to track down their origin.