### PR TITLE
grammar: fix two problems with CallSuffix

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1500,6 +1500,9 @@ Operand = identifier
 DotSuffix   = '.' identifier .
 CallSuffix  = '(' [Arguments [',']] ')' .
 SliceSuffix = '[' [Expression] [':' Test [':' Test]] ']' .
+
+# A CallSuffix does not allow a trailing comma
+# if the last argument is '*' Test or '**' Test.
 ```
 
 TODO: resolve position of +x, -x, and 'not x' in grammar: Operand or UnaryExpr?
@@ -2084,7 +2087,7 @@ print(x)                        # 1
 CallSuffix = '(' [Arguments] ')' .
 
 Arguments = Argument {',' Argument} .
-Argument  = Test | identifier '=' Test | '*' identifier | '**' identifier .
+Argument  = Test | identifier '=' Test | '*' Test | '**' Test .
 ```
 
 A value `f` of type `function` or `builtin_function_or_method` may be called using the expression `f(...)`.

--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -66,8 +66,11 @@ DotSuffix   = '.' identifier .
 CallSuffix  = '(' [Arguments [',']] ')' .
 SliceSuffix = '[' [Expression] [':' Test [':' Test]] ']' .
 
+# A CallSuffix does not allow a trailing comma
+# if the last argument is '*' Test or '**' Test.
+
 Arguments = Argument {',' Argument} .
-Argument  = Test | identifier '=' Test | '*' identifier | '**' identifier .
+Argument  = Test | identifier '=' Test | '*' Test | '**' Test .
 
 ListExpr = '[' [Expression [',']] ']' .
 ListComp = '[' Test {CompClause} ']'.


### PR DESCRIPTION
1. Unlike parameters, the operands of *args and **kwargs used as
   arguments may be any Test expression, not just an identifier.
2. A trailing comma is not permitted after *args or **kwargs.

The implementation already does the right thing (following Python 3).
