### PR TITLE
eval: optimize string==string comparisons, which appear in profiles

### DIFF
--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -69,8 +69,11 @@ func LoadAssertModule() (skylark.StringDict, error) {
 		filename := DataFile("skylark/skylarktest", "assert.sky")
 		thread := new(skylark.Thread)
 		assertErr = skylark.ExecFile(thread, filename, nil, globals)
-		// Expose only the 'assert' struct.
-		assert = skylark.StringDict{"assert": globals["assert"]}
+		// Expose only these items:
+		assert = skylark.StringDict{
+			"assert": globals["assert"],
+			"freeze": globals["freeze"],
+		}
 	})
 	return assert, assertErr
 }

--- a/value.go
+++ b/value.go
@@ -929,6 +929,9 @@ const maxdepth = 10
 
 // Equal reports whether two Skylark values are equal.
 func Equal(x, y Value) (bool, error) {
+	if x, ok := x.(String); ok {
+		return x == y, nil // fast path for an important special case
+	}
 	return EqualDepth(x, y, maxdepth)
 }
 


### PR DESCRIPTION
Also, fix careless breakage caused by hiding 'freeze' from tests.