### PR TITLE
Remove predeclared names from the module globals dict

### DIFF
--- a/cmd/skylark/skylark.go
+++ b/cmd/skylark/skylark.go
@@ -60,7 +60,9 @@ func main() {
 	case 1:
 		// Execute specified file.
 		filename := flag.Args()[0]
-		if err := skylark.ExecFile(thread, filename, nil, globals); err != nil {
+		var err error
+		globals, err = skylark.ExecFile(thread, filename, nil, nil)
+		if err != nil {
 			repl.PrintError(err)
 			os.Exit(1)
 		}

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1048,9 +1048,12 @@ even though applications distinguish these two types.
 
 A built-in function value used in a Boolean context is always considered true.
 
-Many built-in functions are defined in the "universe" block of the environment
-(see [Name Resolution](#name-resolution)), and are thus available to
-all Skylark programs.
+Many built-in functions are predeclared in the environment
+(see [Name Resolution](#name-resolution)).
+Some built-in functions such as `len` are _universal_, that is,
+available to all Skylark programs.
+The host application may predeclare additional built-in functions
+in the environment of a specific module.
 
 Except where noted, built-in functions accept only positional arguments.
 The parameter names serve merely as documentation.
@@ -1096,23 +1099,25 @@ _lexical blocks_, each of which may contain name bindings.
 The tree of blocks is parallel to the syntax tree.
 Blocks are of four kinds.
 
-<!-- Avoid the term "built-in block" since that's also a type. -->
-At the root of the tree is the _universe_ block, which binds constant
-values such as `None`, `True`, and `False`, and built-in functions
-such as `len`, `list`, and so on.
-Skylark programs cannot change the set of universe bindings.
-Because the universe block is shared by all files (modules),
-all values bound in it must be immutable and stateless
-from the perspective of the Skylark program.
+<!-- Avoid the term "built-in" block since that's also a type. -->
+At the root of the tree is the _predeclared_ block,
+which binds several names implicitly.
+The set of predeclared names includes the universal
+constant values `None`, `True`, and `False`, and
+various built-in functions such as `len` and `list`;
+these functions are immutable and stateless.
+An application may pre-declare additional names
+to provide domain-specific functions to that file, for example.
+These additional functions may have side effects on the application.
+Skylark programs cannot change the set of predeclared bindings
+or assign new values to them.
 
-Nested beneath the universe block is the _module_ block, which
+Nested beneath the predeclared block is the _module_ block, which
 contains the bindings of the current file.
 Bindings in the module block (such as `a`, `b`, `c`, and `h` in the
 example) are called _global_.
-The module block is typically empty at the start of the file
+The module block is empty at the start of the file
 and is populated by top-level binding statements,
-but an application may pre-bind one or more global names,
-to provide domain-specific functions to that file, for example.
 
 A module block contains a _function_ block for each top-level
 function, and a _comprehension_ block for each top-level
@@ -2725,16 +2730,17 @@ the language.
 
 ## Built-in constants and functions
 
-The outermost block of the Skylark environment is known as the "universe" block.
+The outermost block of the Skylark environment is known as the "predeclared" block.
 It defines a number of fundamental values and functions needed by all Skylark programs,
-such as `None`, `True`, `False`, and `len`.
+such as `None`, `True`, `False`, and `len`, and possibly additional
+application-specific names.
 
 These names are not reserved words so Skylark programs are free to
 redefine them in a smaller block such as a function body or even at
 the top level of a module.  However, doing so may be confusing to the
 reader.  Nonetheless, this rule permits names to be added to the
-universe block in later versions of the language without breaking
-existing programs.
+upredeclared block in later versions of the language (or
+application-specific dialect) without breaking existing programs.
 
 
 ### None

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2739,7 +2739,7 @@ These names are not reserved words so Skylark programs are free to
 redefine them in a smaller block such as a function body or even at
 the top level of a module.  However, doing so may be confusing to the
 reader.  Nonetheless, this rule permits names to be added to the
-upredeclared block in later versions of the language (or
+redeclared block in later versions of the language (or
 application-specific dialect) without breaking existing programs.
 
 

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2739,7 +2739,7 @@ These names are not reserved words so Skylark programs are free to
 redefine them in a smaller block such as a function body or even at
 the top level of a module.  However, doing so may be confusing to the
 reader.  Nonetheless, this rule permits names to be added to the
-redeclared block in later versions of the language (or
+predeclared block in later versions of the language (or
 application-specific dialect) without breaking existing programs.
 
 

--- a/eval.go
+++ b/eval.go
@@ -548,7 +548,7 @@ func exec(fr *Frame, stmt syntax.Stmt) error {
 		return errReturn
 
 	case *syntax.LoadStmt:
-		module := stmt.Module.Value.(string)
+		module := stmt.ModuleName()
 		if fr.thread.Load == nil {
 			return fr.errorf(stmt.Load, "load not implemented by this application")
 		}

--- a/eval.go
+++ b/eval.go
@@ -105,13 +105,14 @@ func (d StringDict) Has(key string) bool { _, ok := d[key]; return ok }
 // A Frame holds the execution state of a single Skylark function call
 // or module toplevel.
 type Frame struct {
-	thread  *Thread         // thread-associated state
-	parent  *Frame          // caller's frame (or nil)
-	posn    syntax.Position // source position of PC (set during call and error)
-	fn      *Function       // current function (nil at toplevel)
-	globals StringDict      // current global environment
-	locals  []Value         // local variables, starting with parameters
-	result  Value           // operand of current function's return statement
+	thread      *Thread         // thread-associated state
+	parent      *Frame          // caller's frame (or nil)
+	posn        syntax.Position // source position of PC (set during call and error)
+	fn          *Function       // current function (nil at toplevel)
+	predeclared StringDict      // names predeclared for this module
+	globals     []Value         // global variables of enclosing module
+	locals      []Value         // local variables, starting with parameters
+	result      Value           // operand of current function's return statement
 }
 
 func (fr *Frame) errorf(posn syntax.Position, format string, args ...interface{}) *EvalError {
@@ -135,7 +136,7 @@ func (fr *Frame) set(id *syntax.Ident, v Value) {
 	case resolve.Local:
 		fr.locals[id.Index] = v
 	case resolve.Global:
-		fr.globals[id.Name] = v
+		fr.globals[id.Index] = v
 	default:
 		log.Fatalf("%s: set(%s): neither global nor local (%d)", id.NamePos, id.Name, id.Scope)
 	}
@@ -151,16 +152,21 @@ func (fr *Frame) lookup(id *syntax.Ident) (Value, error) {
 	case resolve.Free:
 		return fr.fn.freevars[id.Index], nil
 	case resolve.Global:
-		if v := fr.globals[id.Name]; v != nil {
+		if v := fr.globals[id.Index]; v != nil {
+			return v, nil
+		}
+	case resolve.Predeclared:
+		if v := fr.predeclared[id.Name]; v != nil {
 			return v, nil
 		}
 		if id.Name == "PACKAGE_NAME" {
 			// Gross spec, gross hack.
 			// Users should just call package_name() function.
-			if v, ok := fr.globals["package_name"].(*Builtin); ok {
+			if v, ok := fr.predeclared["package_name"].(*Builtin); ok {
 				return v.fn(fr.thread, v, nil, nil)
 			}
 		}
+		return nil, fr.errorf(id.NamePos, "internal error: predeclared variable %s is uninitialized", id.Name)
 	case resolve.Universal:
 		return Universe[id.Name], nil
 	}
@@ -223,8 +229,13 @@ func (e *EvalError) Stack() []*Frame {
 //
 // If ExecFile fails during evaluation, it returns an *EvalError
 // containing a backtrace.
-func ExecFile(thread *Thread, filename string, src interface{}, globals StringDict) error {
-	return Exec(ExecOptions{Thread: thread, Filename: filename, Source: src, Globals: globals})
+func ExecFile(thread *Thread, filename string, src interface{}, predeclared StringDict) (StringDict, error) {
+	return Exec(ExecOptions{
+		Thread:      thread,
+		Filename:    filename,
+		Source:      src,
+		Predeclared: predeclared,
+	})
 }
 
 // ExecOptions specifies the arguments to Exec.
@@ -240,9 +251,9 @@ type ExecOptions struct {
 	// instead of Filename.  See syntax.Parse for details.
 	Source interface{}
 
-	// Globals is the environment of the module.
-	// It may be modified during execution.
-	Globals StringDict
+	// Predeclared defines the predeclared names specific to this module.
+	// Execution does not modify this dictionary.
+	Predeclared StringDict
 
 	// BeforeExec is an optional function that is called after the
 	// syntax tree has been resolved but before execution.  If it
@@ -252,79 +263,93 @@ type ExecOptions struct {
 
 // Exec is a variant of ExecFile that gives the client greater control
 // over optional features.
-func Exec(opts ExecOptions) error {
+func Exec(opts ExecOptions) (StringDict, error) {
 	if debug {
 		fmt.Printf("ExecFile %s\n", opts.Filename)
 		defer fmt.Printf("ExecFile %s done\n", opts.Filename)
 	}
 	f, err := syntax.Parse(opts.Filename, opts.Source, 0)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	globals := opts.Globals
-	if err := resolve.File(f, globals.Has, Universe.Has); err != nil {
-		return err
+	predeclared := opts.Predeclared
+	if err := resolve.File(f, predeclared.Has, Universe.Has); err != nil {
+		return nil, err
 	}
 
 	thread := opts.Thread
 
 	if opts.BeforeExec != nil {
 		if err := opts.BeforeExec(thread, f); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	fr := thread.Push(globals, len(f.Locals))
+	globals := make([]Value, len(f.Globals))
+	fr := thread.Push(predeclared, globals, len(f.Locals))
 	err = fr.ExecStmts(f.Stmts)
 	thread.Pop()
 
-	// Freeze the global environment.
-	globals.Freeze()
+	// Convert the global environment to a map, and freeze it.
+	// We return a (partial) map even in case of error.
+	globalsMap := make(StringDict, len(f.Globals))
+	for i, id := range f.Globals {
+		if v := globals[i]; v != nil {
+			v.Freeze()
+			globalsMap[id.Name] = v
+		}
+	}
 
-	return err
+	return globalsMap, err
 }
 
 // Push pushes a new Frame on the specified thread's stack, and returns it.
 // It must be followed by a call to Pop when the frame is no longer needed.
-func (thread *Thread) Push(globals StringDict, nlocals int) *Frame {
+//
+// Most clients do not need this low-level function; use ExecFile or Eval instead.
+func (thread *Thread) Push(predeclared StringDict, globals []Value, nlocals int) *Frame {
 	fr := &Frame{
-		thread:  thread,
-		parent:  thread.frame,
-		globals: globals,
-		locals:  make([]Value, nlocals),
+		thread:      thread,
+		parent:      thread.frame,
+		predeclared: predeclared,
+		globals:     globals,
+		locals:      make([]Value, nlocals),
 	}
 	thread.frame = fr
 	return fr
 }
 
 // Pop removes the topmost frame from the thread's stack.
+//
+// Most clients do not need this low-level function; use ExecFile or Eval instead.
 func (thread *Thread) Pop() {
 	thread.frame = thread.frame.parent
 }
 
 // Eval parses, resolves, and evaluates an expression within the
-// specified global environment.
+// specified (predeclared) environment.
 //
-// Evaluation cannot mutate the globals dictionary itself, though it may
-// modify variables reachable from the dictionary.
+// Evaluation cannot mutate the environment dictionary itself,
+// though it may modify variables reachable from the dictionary.
 //
 // The filename and src parameters are as for syntax.Parse.
 //
 // If Eval fails during evaluation, it returns an *EvalError
 // containing a backtrace.
-func Eval(thread *Thread, filename string, src interface{}, globals StringDict) (Value, error) {
+func Eval(thread *Thread, filename string, src interface{}, env StringDict) (Value, error) {
 	expr, err := syntax.ParseExpr(filename, src, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	locals, err := resolve.Expr(expr, globals.Has, Universe.Has)
+	locals, err := resolve.Expr(expr, env.Has, Universe.Has)
 	if err != nil {
 		return nil, err
 	}
 
-	fr := thread.Push(globals, len(locals))
+	// There are no globals.
+	fr := thread.Push(env, nil, len(locals))
 	v, err := eval(fr, expr)
 	thread.Pop()
 	return v, err
@@ -523,7 +548,7 @@ func exec(fr *Frame, stmt syntax.Stmt) error {
 		return errReturn
 
 	case *syntax.LoadStmt:
-		module := stmt.ModuleName()
+		module := stmt.Module.Value.(string)
 		if fr.thread.Load == nil {
 			return fr.errorf(stmt.Load, "load not implemented by this application")
 		}
@@ -1687,12 +1712,13 @@ func evalFunction(fr *Frame, pos syntax.Position, name string, function *syntax.
 	}
 
 	return &Function{
-		name:     name,
-		position: pos,
-		syntax:   function,
-		globals:  fr.globals,
-		defaults: defaults,
-		freevars: freevars,
+		name:        name,
+		position:    pos,
+		syntax:      function,
+		predeclared: fr.predeclared,
+		globals:     fr.globals,
+		defaults:    defaults,
+		freevars:    freevars,
 	}, nil
 }
 
@@ -1711,7 +1737,7 @@ func (fn *Function) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, err
 		}
 	}
 
-	fr := thread.Push(fn.globals, len(fn.syntax.Locals))
+	fr := thread.Push(fn.predeclared, fn.globals, len(fn.syntax.Locals))
 	fr.fn = fn
 	err := fn.setArgs(fr, args, kwargs)
 	if err == nil {

--- a/example_test.go
+++ b/example_test.go
@@ -28,10 +28,11 @@ squares = [x*x for x in range(10)]
 	thread := &skylark.Thread{
 		Print: func(_ *skylark.Thread, msg string) { fmt.Println(msg) },
 	}
-	globals := skylark.StringDict{
+	predeclared := skylark.StringDict{
 		"greeting": skylark.String("hello"),
 	}
-	if err := skylark.ExecFile(thread, "apparent/filename.sky", data, globals); err != nil {
+	globals, err := skylark.ExecFile(thread, "apparent/filename.sky", data, predeclared)
+	if err != nil {
 		if evalErr, ok := err.(*skylark.EvalError); ok {
 			log.Fatal(evalErr.Backtrace())
 		}
@@ -54,7 +55,6 @@ squares = [x*x for x in range(10)]
 	// hello, world
 	//
 	// Globals:
-	// greeting (string) = "hello"
 	// squares (list) = [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
 }
 
@@ -89,8 +89,7 @@ func ExampleLoadSequential() {
 			// Load and initialize the module in a new thread.
 			data := fakeFilesystem[module]
 			thread := &skylark.Thread{Load: load}
-			globals := make(skylark.StringDict)
-			err := skylark.ExecFile(thread, module, data, globals)
+			globals, err := skylark.ExecFile(thread, module, data, nil)
 			e = &entry{globals, err}
 
 			// Update the cache.
@@ -243,12 +242,7 @@ func (c *cache) doLoad(cc *cycleChecker, module string) (skylark.StringDict, err
 		},
 	}
 	data := c.fakeFilesystem[module]
-	globals := make(skylark.StringDict)
-	err := skylark.ExecFile(thread, module, data, globals)
-	if err != nil {
-		return nil, err
-	}
-	return globals, nil
+	return skylark.ExecFile(thread, module, data, nil)
 }
 
 // -- concurrent cycle checking --

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -163,6 +163,7 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 }
 
 // execFileNoFreeze is skylark.ExecFile without globals.Freeze().
+// The global names from the previous call become the predeclared names of this call.
 func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.StringDict) error {
 	// parse
 	f, err := syntax.Parse("<stdin>", src, 0)
@@ -173,13 +174,23 @@ func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.S
 	// resolve
 	if err := resolve.File(f, globals.Has, skylark.Universe.Has); err != nil {
 		return err
-
 	}
 
 	// execute
-	fr := thread.Push(globals, len(f.Locals))
-	defer thread.Pop()
-	return fr.ExecStmts(f.Stmts)
+	globalsArray := make([]skylark.Value, len(f.Globals))
+	fr := thread.Push(globals, globalsArray, len(f.Locals))
+	err = fr.ExecStmts(f.Stmts)
+	thread.Pop()
+
+	// Copy globals back to the caller's map.
+	// If execution failed, some globals may be undefined.
+	for i, id := range f.Globals {
+		if v := globalsArray[i]; v != nil {
+			globals[id.Name] = v
+		}
+	}
+
+	return err
 }
 
 // PrintError prints the error to stderr,
@@ -216,8 +227,7 @@ func MakeLoad() func(thread *skylark.Thread, module string) (skylark.StringDict,
 
 			// Load it.
 			thread := &skylark.Thread{Load: thread.Load}
-			globals := make(skylark.StringDict)
-			err := skylark.ExecFile(thread, module, nil, globals)
+			globals, err := skylark.ExecFile(thread, module, nil, nil)
 			e = &entry{globals, err}
 
 			// Update the cache.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -163,7 +163,6 @@ func rep(rl *readline.Instance, thread *skylark.Thread, globals skylark.StringDi
 }
 
 // execFileNoFreeze is skylark.ExecFile without globals.Freeze().
-// The global names from the previous call become the predeclared names of this call.
 func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.StringDict) error {
 	// parse
 	f, err := syntax.Parse("<stdin>", src, 0)
@@ -177,6 +176,7 @@ func execFileNoFreeze(thread *skylark.Thread, src interface{}, globals skylark.S
 	}
 
 	// execute
+	// The global names from the previous call become the predeclared names of this call.
 	globalsArray := make([]skylark.Value, len(f.Globals))
 	fr := thread.Push(globals, globalsArray, len(f.Locals))
 	err = fr.ExecStmts(f.Stmts)

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -97,8 +97,13 @@ var (
 // The isPredeclared and isUniversal predicates report whether a name is
 // a pre-declared identifier (visible in the current module) or a
 // universal identifier (visible in every module).
-// Typical values are predeclared.Has and Universe.Has, respectively, where
-// predeclared is the module's StringDict of predeclared names.
+// Clients should typically pass predeclared.Has for the first and
+// skylark.Universe.Has for the second, where predeclared is the
+// module's StringDict of predeclared names and skylark.Universe is the
+// standard set of built-ins.
+// The isUniverse predicate is supplied a parameter to avoid a cyclic
+// dependency upon skylark.Universe, not because users should ever need
+// to redefine it.
 func File(file *syntax.File, isPredeclared, isUniversal func(name string) bool) error {
 	r := newResolver(isPredeclared, isUniversal)
 	r.stmts(file.Stmts)
@@ -122,11 +127,7 @@ func File(file *syntax.File, isPredeclared, isUniversal func(name string) bool) 
 // Expr resolves the specified expression.
 // It returns the local variables bound within the expression.
 //
-// The isPredeclared and isUniversal predicates report whether a name is
-// a pre-declared identifier (visible in the current module) or a
-// universal identifier (visible in every module).
-// Typical values are predeclared.Has and Universe.Has, respectively, where
-// predeclared is the module's StringDict of predeclared names.
+// The isPredeclared and isUniversal predicates behave as for the File function.
 func Expr(expr syntax.Expr, isPredeclared, isUniversal func(name string) bool) ([]*syntax.Ident, error) {
 	r := newResolver(isPredeclared, isUniversal)
 	r.expr(expr)

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -21,7 +21,7 @@ package resolve
 // As an optimization, the resolver classifies each predeclared name as
 // either universal (e.g. None, len) or per-module (e.g. glob in Bazel's
 // build language), enabling the evaluator to share the representation
-// of the universal environment names across all modules.
+// of the universal environment across all modules.
 //
 // The lexical environment is a tree of blocks with the module block at
 // its root.  The module's child blocks may be of two kinds: functions
@@ -40,7 +40,7 @@ package resolve
 // As we finish resolving each function, we inspect all the uses within
 // that function and discard ones that were found to be local. The
 // remaining ones must be either free (local to some lexically enclosing
-// function), or global (including predeclared), but we cannot tell
+// function), or nonlocal (global or predeclared), but we cannot tell
 // which until we have finished inspecting the outermost enclosing
 // function. At that point, we can distinguish local from global names
 // (and this is when Python would compute free variables).

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -13,11 +13,15 @@
 package resolve
 
 // All references to names are statically resolved.  Names may be
-// universal (e.g. None, len), global and predeclared (e.g. glob in the
-// build language), global and user-defined (e.g. x=1 at toplevel), or
-// local to a function or module-level comprehension.  The resolver maps
-// each local name to a small integer for fast and compact
-// representation in the evaluator.
+// predeclared, global, or local to a function or module-level comprehension.
+// The resolver maps each global name to a small integer and each local
+// name to a small integer; these integers enable a fast and compact
+// representation of globals and locals in the evaluator.
+//
+// As an optimization, the resolver classifies each predeclared name as
+// either universal (e.g. None, len) or per-module (e.g. glob in Bazel's
+// build language), enabling the evaluator to share the representation
+// of the universal environment names across all modules.
 //
 // The lexical environment is a tree of blocks with the module block at
 // its root.  The module's child blocks may be of two kinds: functions
@@ -34,12 +38,12 @@ package resolve
 // local variable to the enclosing function.
 //
 // As we finish resolving each function, we inspect all the uses within
-// that function and discard ones that were found to be local.  The
+// that function and discard ones that were found to be local. The
 // remaining ones must be either free (local to some lexically enclosing
-// function) or global/universal, but we cannot tell which until we have
-// finished inspecting the outermost enclosing function.  At that point,
-// we can distinguish local from global names (and this is when Python
-// would compute free variables).
+// function), or global (including predeclared), but we cannot tell
+// which until we have finished inspecting the outermost enclosing
+// function. At that point, we can distinguish local from global names
+// (and this is when Python would compute free variables).
 //
 // However, Skylark additionally requires that all references to global
 // names are satisfied by some declaration in the current module;
@@ -90,13 +94,13 @@ var (
 
 // File resolves the specified file.
 //
-// The isPredeclaredGlobal and isUniversal predicates report whether a
-// name is a pre-declared global identifier (in the current module) or a
-// universal identifier (in every module).
-// Typical values are globals.Has and Universe.Has, respectively, where
-// globals is the current module's StringDict.
-func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) bool) error {
-	r := newResolver(isPredeclaredGlobal, isUniversal)
+// The isPredeclared and isUniversal predicates report whether a name is
+// a pre-declared identifier (visible in the current module) or a
+// universal identifier (visible in every module).
+// Typical values are predeclared.Has and Universe.Has, respectively, where
+// predeclared is the module's StringDict of predeclared names.
+func File(file *syntax.File, isPredeclared, isUniversal func(name string) bool) error {
+	r := newResolver(isPredeclared, isUniversal)
 	r.stmts(file.Stmts)
 
 	r.env.resolveLocalUses()
@@ -107,6 +111,7 @@ func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) 
 	r.resolveNonLocalUses(r.env)
 
 	file.Locals = r.moduleLocals
+	file.Globals = r.moduleGlobals
 
 	if len(r.errors) > 0 {
 		return r.errors
@@ -117,13 +122,13 @@ func File(file *syntax.File, isPredeclaredGlobal, isUniversal func(name string) 
 // Expr resolves the specified expression.
 // It returns the local variables bound within the expression.
 //
-// The isPredeclaredGlobal and isUniversal predicates report whether a
-// name is a pre-declared global identifier (in the current module) or a
-// universal identifier (in every module).
-// Typical values are globals.Has and Universe.Has, respectively, where
-// globals is the current module's StringDict.
-func Expr(expr syntax.Expr, isPredeclaredGlobal, isUniversal func(name string) bool) ([]*syntax.Ident, error) {
-	r := newResolver(isPredeclaredGlobal, isUniversal)
+// The isPredeclared and isUniversal predicates report whether a name is
+// a pre-declared identifier (visible in the current module) or a
+// universal identifier (visible in every module).
+// Typical values are predeclared.Has and Universe.Has, respectively, where
+// predeclared is the module's StringDict of predeclared names.
+func Expr(expr syntax.Expr, isPredeclared, isUniversal func(name string) bool) ([]*syntax.Ident, error) {
+	r := newResolver(isPredeclared, isUniversal)
 	r.expr(expr)
 	r.env.resolveLocalUses()
 	r.resolveNonLocalUses(r.env) // globals & universals
@@ -150,29 +155,31 @@ func (e Error) Error() string { return e.Pos.String() + ": " + e.Msg }
 type Scope uint8
 
 const (
-	Undefined Scope = iota // name is not defined
-	Local                  // name is local to its function
-	Free                   // name is local to some enclosing function
-	Global                 // name is global to module
-	Universal              // name is universal (e.g. len)
+	Undefined   Scope = iota // name is not defined
+	Local                    // name is local to its function
+	Free                     // name is local to some enclosing function
+	Global                   // name is global to module
+	Predeclared              // name is predeclared for this module (e.g. glob)
+	Universal                // name is universal (e.g. len)
 )
 
 var scopeNames = [...]string{
-	Undefined: "undefined",
-	Local:     "local",
-	Free:      "free",
-	Global:    "global",
-	Universal: "universal",
+	Undefined:   "undefined",
+	Local:       "local",
+	Free:        "free",
+	Global:      "global",
+	Predeclared: "predeclared",
+	Universal:   "universal",
 }
 
 func (scope Scope) String() string { return scopeNames[scope] }
 
-func newResolver(isPredeclaredGlobal, isUniversal func(name string) bool) *resolver {
+func newResolver(isPredeclared, isUniversal func(name string) bool) *resolver {
 	return &resolver{
-		env:                 new(block), // module block
-		isPredeclaredGlobal: isPredeclaredGlobal,
-		isUniversal:         isUniversal,
-		globals:             make(map[string]syntax.Position),
+		env:           new(block), // module block
+		isPredeclared: isPredeclared,
+		isUniversal:   isUniversal,
+		globals:       make(map[string]*syntax.Ident),
 	}
 }
 
@@ -184,16 +191,17 @@ type resolver struct {
 
 	// moduleLocals contains the local variables of the module
 	// (due to comprehensions outside any function).
-	moduleLocals []*syntax.Ident
+	// moduleGlobals contains the global variables of the module.
+	moduleLocals  []*syntax.Ident
+	moduleGlobals []*syntax.Ident
 
-	// globals contains the names of global variables defined
-	// within the module (but not predeclared ones).
-	// The position is that of the original binding.
-	globals map[string]syntax.Position
+	// globals maps each global name in the module
+	// to its first binding occurrence.
+	globals map[string]*syntax.Ident
 
 	// These predicates report whether a name is
-	// a pre-declared global or universal.
-	isPredeclaredGlobal, isUniversal func(name string) bool
+	// pre-declared, either in this module or universally.
+	isPredeclared, isUniversal func(name string) bool
 
 	loops int // number of enclosing for loops
 
@@ -283,20 +291,22 @@ type use struct {
 func (r *resolver) bind(id *syntax.Ident, allowRebind bool) bool {
 	// Binding outside any local (comprehension/function) block?
 	if r.env.isModule() {
-		prevPos, ok := r.globals[id.Name]
+		id.Scope = uint8(Global)
+		prev, ok := r.globals[id.Name]
 		if ok {
-			id.Scope = uint8(Global)
-
 			// Global reassignments are permitted only if
 			// they are of the form x += y.  We can't tell
 			// statically whether it's a reassignment
 			// (e.g. int += int) or a mutation (list += list).
 			if !allowRebind && !AllowGlobalReassign {
-				r.errorf(id.NamePos, "cannot reassign global %s declared at %s", id.Name, prevPos)
+				r.errorf(id.NamePos, "cannot reassign global %s declared at %s", id.Name, prev.NamePos)
 			}
+			id.Index = prev.Index
 		} else {
-			id.Scope = uint8(Global)
-			r.globals[id.Name] = id.NamePos
+			// first global binding of this name
+			r.globals[id.Name] = id
+			id.Index = len(r.moduleGlobals)
+			r.moduleGlobals = append(r.moduleGlobals, id)
 		}
 		return ok
 	}
@@ -330,13 +340,15 @@ func (r *resolver) use(id *syntax.Ident) {
 	b.uses = append(b.uses, use{id, r.env})
 }
 
-func (r *resolver) useGlobal(id *syntax.Ident) (scope Scope) {
-	if _, ok := r.globals[id.Name]; ok {
+func (r *resolver) useGlobal(id *syntax.Ident) binding {
+	var scope Scope
+	if prev, ok := r.globals[id.Name]; ok {
 		scope = Global // use of global declared by module
-	} else if r.isPredeclaredGlobal(id.Name) {
-		scope = Global // use of pre-declared global
+		id.Index = prev.Index
+	} else if r.isPredeclared(id.Name) {
+		scope = Predeclared // use of pre-declared
 	} else if id.Name == "PACKAGE_NAME" {
-		scope = Global // nasty hack in Skylark spec; will go away (b/34240042).
+		scope = Predeclared // nasty hack in Skylark spec; will go away (b/34240042).
 	} else if r.isUniversal(id.Name) {
 		scope = Universal // use of universal name
 		if !AllowFloat && id.Name == "float" {
@@ -350,7 +362,7 @@ func (r *resolver) useGlobal(id *syntax.Ident) (scope Scope) {
 		r.errorf(id.NamePos, "undefined: %s", id.Name)
 	}
 	id.Scope = uint8(scope)
-	return scope
+	return binding{scope, id.Index}
 }
 
 // resolveLocalUses is called when leaving a container (function/module)
@@ -755,7 +767,7 @@ func (r *resolver) lookupLexical(id *syntax.Ident, env *block) (bind binding) {
 
 	// Is this the module block?
 	if env.isModule() {
-		return binding{r.useGlobal(id), 0} // global or universal, or not found
+		return r.useGlobal(id) // global, predeclared, or not found
 	}
 
 	// Defined in this block?

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -30,7 +30,7 @@ func TestResolve(t *testing.T) {
 		resolve.AllowSet = option(chunk.Source, "set")
 		resolve.AllowGlobalReassign = option(chunk.Source, "global_reassign")
 
-		if err := resolve.File(f, isPredeclaredGlobal, isUniversal); err != nil {
+		if err := resolve.File(f, isPredeclared, isUniversal); err != nil {
 			for _, err := range err.(resolve.ErrorList) {
 				chunk.GotError(int(err.Pos.Line), err.Msg)
 			}
@@ -49,7 +49,7 @@ func TestDefVarargsAndKwargsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resolve.File(file, isPredeclaredGlobal, isUniversal); err != nil {
+	if err := resolve.File(file, isPredeclared, isUniversal); err != nil {
 		t.Fatal(err)
 	}
 	fn := file.Stmts[0].(*syntax.DefStmt)
@@ -68,7 +68,7 @@ func TestLambdaVarargsAndKwargsSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resolve.File(file, isPredeclaredGlobal, isUniversal); err != nil {
+	if err := resolve.File(file, isPredeclared, isUniversal); err != nil {
 		t.Fatal(err)
 	}
 	lam := file.Stmts[0].(*syntax.AssignStmt).RHS.(*syntax.LambdaExpr)
@@ -80,7 +80,6 @@ func TestLambdaVarargsAndKwargsSet(t *testing.T) {
 	}
 }
 
-func isPredeclaredGlobal(name string) bool { return strings.HasPrefix(name, "G") }
-func isUniversal(name string) bool {
-	return strings.HasPrefix(name, "B") || name == "float"
-}
+func isPredeclared(name string) bool { return name == "M" }
+
+func isUniversal(name string) bool { return name == "U" || name == "float" }

--- a/resolve/testdata/resolve.sky
+++ b/resolve/testdata/resolve.sky
@@ -1,4 +1,8 @@
 # Tests of resolver errors.
+#
+# The initial environment contains the predeclared names "M"
+# (module-specific) and "U" (universal). This distinction
+# should be unobservable to the Skylark program.
 
 # use of declared global
 x = 1
@@ -16,53 +20,55 @@ _ = x ### "undefined: x"
 ---
 # redeclaration of global
 x = 1
-x = 2 ### "cannot reassign global x declared at .*resolve.sky:18:1"
+x = 2 ### "cannot reassign global x declared at .*resolve.sky:22:1"
 
 ---
-# redeclaration of predeclared global or built-in
+# Redeclaration of predeclared names is allowed.
+#
+# This rule permits tool maintainers to add members to the predeclared
+# environment without breaking existing programs.
 
-# This rule permits tool maintainers to add members to the global
-# environment without breaking exsiting programs.
+# module-specific predeclared name
+M = 1 # ok
+M = 2 ### "cannot reassign global M declared at .*/resolve.sky"
 
-G = 1 # ok
-G = 2 ### "cannot reassign global G declared at .*/resolve.sky"
-
-B = 1 # ok
-B = 1 ### "cannot reassign global B declared at .*/resolve.sky"
+# universal predeclared name
+U = 1 # ok
+U = 1 ### "cannot reassign global U declared at .*/resolve.sky"
 
 ---
-# reference to built-in
-B()
+# reference to predeclared name
+M()
 
 ---
 # locals may be referenced before they are defined
 
 def f():
-   G(x) # dynamic error
+   M(x) # dynamic error
    x = 1
 
 ---
 # Various forms of assignment:
 
 def f(x): # parameter
-    G(x)
-    G(y) ### "undefined: y"
+    M(x)
+    M(y) ### "undefined: y"
 
 (a, b) = 1, 2
-G(a)
-G(b)
-G(c) ### "undefined: c"
+M(a)
+M(b)
+M(c) ### "undefined: c"
 
 [p, q] = 1, 2
-G(p)
-G(q)
-G(r) ### "undefined: r"
+M(p)
+M(q)
+M(r) ### "undefined: r"
 
 ---
 # a comprehension introduces a separate lexical block
 
 _ = [x for x in "abc"]
-G(x) ### "undefined: x"
+M(x) ### "undefined: x"
 
 ---
 # Functions may have forward refs.   (option:lambda option:nesteddef)
@@ -97,12 +103,12 @@ def f(a):
   if 1==1:
     b = 1
   c = 1
-  G(a) # ok: param
-  G(b) # ok: maybe bound local
-  G(c) # ok: bound local
-  G(d) # NB: we don't do a use-before-def check on local vars!
-  G(e) # ok: global
-  G(f) # ok: global
+  M(a) # ok: param
+  M(b) # ok: maybe bound local
+  M(c) # ok: bound local
+  M(d) # NB: we don't do a use-before-def check on local vars!
+  M(e) # ok: global
+  M(f) # ok: global
   d = 1
 
 e = 1
@@ -114,7 +120,7 @@ e = 1
 x = 1
 
 def f():
-  G(x) # dynamic error: reference to undefined local
+  M(x) # dynamic error: reference to undefined local
   x = 2
 
 f()
@@ -169,7 +175,7 @@ pass
 # Positional arguments (and required parameters)
 # must appear before named arguments (and optional parameters).
 
-G(x=1, 2) ### `positional argument may not follow named`
+M(x=1, 2) ### `positional argument may not follow named`
 
 def f(x=1, y): pass ### `required parameter may not follow optional`
 ---

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -28,11 +28,11 @@ func Test(t *testing.T) {
 	thread := &skylark.Thread{Load: load}
 	skylarktest.SetReporter(thread, t)
 	filename := filepath.Join(testdata, "testdata/struct.sky")
-	globals := skylark.StringDict{
+	predeclared := skylark.StringDict{
 		"struct": skylark.NewBuiltin("struct", skylarkstruct.Make),
 		"gensym": skylark.NewBuiltin("gensym", gensym),
 	}
-	if err := skylark.ExecFile(thread, filename, nil, globals); err != nil {
+	if _, err := skylark.ExecFile(thread, filename, nil, predeclared); err != nil {
 		if err, ok := err.(*skylark.EvalError); ok {
 			t.Fatal(err.Backtrace())
 		}

--- a/skylarktest/assert.sky
+++ b/skylarktest/assert.sky
@@ -1,11 +1,11 @@
 
-# Built-ins defined in this module:
+# Predeclared built-ins for this module:
 #
 # error(msg): report an error in Go's test framework without halting execution.
 # catch(f): evaluate f() and returns its evaluation error message, if any
 # matches(str, pattern): report whether str matches regular expression pattern.
 # struct: a constructor for a simple HasFields implementation.
-# freeze(x): freeze the value x and everything reachable from it.
+# _freeze(x): freeze the value x and everything reachable from it.
 #
 # Clients may use these functions to define their own testing abstractions.
 
@@ -37,7 +37,7 @@ def _fails(f, pattern):
   elif not matches(pattern, msg):
       error("regular expression (%s) did not match error (%s)" % (pattern, msg))
 
-freeze = freeze # an exported global whose value is the built-in freeze function
+freeze = _freeze # an exported global whose value is the built-in freeze function
 
 assert = struct(
     fail = error,

--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -59,21 +59,16 @@ var (
 // It is concurrency-safe and idempotent.
 func LoadAssertModule() (skylark.StringDict, error) {
 	once.Do(func() {
-		globals := skylark.StringDict{
+		predeclared := skylark.StringDict{
 			"error":   skylark.NewBuiltin("error", error_),
 			"catch":   skylark.NewBuiltin("catch", catch),
 			"matches": skylark.NewBuiltin("matches", matches),
 			"struct":  skylark.NewBuiltin("struct", skylarkstruct.Make),
-			"freeze":  skylark.NewBuiltin("freeze", freeze),
+			"_freeze": skylark.NewBuiltin("freeze", freeze),
 		}
 		filename := DataFile("skylark/skylarktest", "assert.sky")
 		thread := new(skylark.Thread)
-		assertErr = skylark.ExecFile(thread, filename, nil, globals)
-		// Expose only these items:
-		assert = skylark.StringDict{
-			"assert": globals["assert"],
-			"freeze": globals["freeze"],
-		}
+		assert, assertErr = skylark.ExecFile(thread, filename, nil, predeclared)
 	})
 	return assert, assertErr
 }

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -71,7 +71,8 @@ type File struct {
 	Stmts []Stmt
 
 	// set by resolver:
-	Locals []*Ident // this file's (comprehension-)local variables
+	Locals  []*Ident // this file's (comprehension-)local variables
+	Globals []*Ident // this file's global variables
 }
 
 func (x *File) Span() (start, end Position) {
@@ -259,8 +260,8 @@ type Ident struct {
 
 	// set by resolver:
 
-	Scope uint8 // one of resolve.{Undefined,Local,Free,Global,Builtin}
-	Index int   // index into enclosing {DefStmt,File}.Locals (if scope==Local) or DefStmt.FreeVars (if scope==Free)
+	Scope uint8 // see type resolve.Scope
+	Index int   // index into enclosing {DefStmt,File}.Locals (if scope==Local) or DefStmt.FreeVars (if scope==Free) or File.Globals (if scope==Global)
 }
 
 func (x *Ident) Span() (start, end Position) {

--- a/testdata/misc.sky
+++ b/testdata/misc.sky
@@ -97,3 +97,17 @@ assert.eq(1 + \
 # A regression test for error position information.
 
 _ = {}.get(1, default=2) ### "get: unexpected keyword arguments"
+
+---
+# Load exposes explicitly declared globals from other modules.
+load('assert.sky', 'assert', 'freeze')
+assert.eq(str(freeze), '<built-in function freeze>')
+
+---
+# Load does not expose pre-declared globals from other modules.
+# See github.com/google/skylark/issues/75.
+load('assert.sky', 'assert', 'matches') ### "matches not found in module"
+
+---
+# Load does not expose universals accessible in other modules.
+load('assert.sky', 'len') ### "len not found in module"

--- a/value.go
+++ b/value.go
@@ -456,12 +456,13 @@ func (*stringIterator) Done() {}
 
 // A Function is a function defined by a Skylark def statement.
 type Function struct {
-	name     string          // "lambda" for anonymous functions
-	position syntax.Position // position of def or lambda token
-	syntax   *syntax.Function
-	globals  StringDict
-	defaults Tuple
-	freevars Tuple
+	name        string          // "lambda" for anonymous functions
+	position    syntax.Position // position of def or lambda token
+	syntax      *syntax.Function
+	predeclared StringDict // names predeclared in the current module
+	globals     []Value    // globals of the current module
+	defaults    Tuple
+	freevars    Tuple
 }
 
 func (fn *Function) Name() string          { return fn.name }


### PR DESCRIPTION
Previously, the Skylark spec and Go implementation had a notion of "predeclared globals", which are module globals that have a value before execution begins, such as the 'glob' function in the Bazel build language.  This is undesirable because it causes every module to appear to define 'glob', and it makes this name accessible to other modules through the load statement.

This CL changes the spec and implementation to match the Bazel behavior: predeclared names like glob are no longer part of the module's globals dictionary, but are treated similar to universal names such as None and len. From the Skylark program's perspective, there is no difference between per-module predeclared names and universal predeclared names, and the spec now uses only the term "predeclared". However, the resolver distinguishes them as an optimization as this allows the evaluator to use separate dictionaries to represent the universal and the per-module portions.

API CHANGE: The ExecFile function has changed, and so must all its callers. Previously, it accepted the globals dictionary as a parameter, populated with predeclared names, and execution would add more names to this dictionary.  Now, it accepts the predeclared dictionary (which it does not modify), and returns the globals dictionary.

Also: the resolver now assigns an index to each global, allowing the evaluator to use a flat representation for globals similar to that for locals.

Fixes #75

(See also Google internal issue b/74460309)