### PR TITLE
Make DataFile work with Bazel, too.

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -92,7 +92,7 @@ func TestEvalExpr(t *testing.T) {
 }
 
 func TestExecFile(t *testing.T) {
-	testdata := skylarktest.DataFile("skylark", ".")
+	testdata := skylarktest.DataFile("", ".")
 	thread := &skylark.Thread{Load: load}
 	skylarktest.SetReporter(thread, t)
 	for _, file := range []string{
@@ -342,7 +342,7 @@ f()
 }
 
 func Benchmark(b *testing.B) {
-	testdata := skylarktest.DataFile("skylark", ".")
+	testdata := skylarktest.DataFile("", ".")
 	thread := new(skylark.Thread)
 	for _, file := range []string{
 		"testdata/benchmark.sky",

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestResolve(t *testing.T) {
-	filename := skylarktest.DataFile("skylark/resolve", "testdata/resolve.sky")
+	filename := skylarktest.DataFile("resolve", "testdata/resolve.sky")
 	for _, chunk := range chunkedfile.Read(filename, t) {
 		f, err := syntax.Parse(filename, chunk.Source, 0)
 		if err != nil {

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func Test(t *testing.T) {
-	testdata := skylarktest.DataFile("skylark/skylarkstruct", ".")
+	testdata := skylarktest.DataFile("skylarkstruct", ".")
 	thread := &skylark.Thread{Load: load}
 	skylarktest.SetReporter(thread, t)
 	filename := filepath.Join(testdata, "testdata/struct.sky")

--- a/skylarktest/bazeltest.go
+++ b/skylarktest/bazeltest.go
@@ -1,0 +1,25 @@
+// +build bazel
+
+// Copyright 2018 The Bazel Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Rebinds DataFile, so that it builds data paths as expected by Bazel.
+
+package skylarktest
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	testDir := os.Getenv("TEST_SRCDIR")
+	DataFile = func(subdir, filename string) string {
+		// Late check testDir, to only panic when we actually need it.
+		if testDir == "" {
+			panic("Environment variable TEST_SRCDIR unset or empty.")
+		}
+		return filepath.Join(testDir, "com_github_google_skylark", subdir, filename)
+	}
+}

--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -66,7 +66,7 @@ func LoadAssertModule() (skylark.StringDict, error) {
 			"struct":  skylark.NewBuiltin("struct", skylarkstruct.Make),
 			"freeze":  skylark.NewBuiltin("freeze", freeze),
 		}
-		filename := DataFile("skylark/skylarktest", "assert.sky")
+		filename := DataFile("skylarktest", "assert.sky")
 		thread := new(skylark.Thread)
 		assertErr = skylark.ExecFile(thread, filename, nil, globals)
 		// Expose only these items:
@@ -134,9 +134,11 @@ func freeze(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwar
 }
 
 // DataFile returns the effective filename of the specified
-// test data resource.  The function abstracts differences between
-// 'go build', under which a test runs in its package directory,
-// and Blaze, under which a test runs in the root of the tree.
-var DataFile = func(pkgdir, filename string) string {
-	return filepath.Join(build.Default.GOPATH, "src/github.com/google", pkgdir, filename)
+// test data resource. The function abstracts differences between
+// - 'go build' (under which a test runs in its package directory),
+// - Blaze (under which a test runs in the root of the tree) and
+// - Bazel/rules_go (under which a test runs in a different package directory)
+// The default behavior works for 'go build'.
+var DataFile = func(subdir, filename string) string {
+	return filepath.Join(build.Default.GOPATH, "src/github.com/google/skylark", subdir, filename)
 }

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -332,7 +332,7 @@ func writeTree(out *bytes.Buffer, x reflect.Value) {
 }
 
 func TestParseErrors(t *testing.T) {
-	filename := skylarktest.DataFile("skylark/syntax", "testdata/errors.sky")
+	filename := skylarktest.DataFile("syntax", "testdata/errors.sky")
 	for _, chunk := range chunkedfile.Read(filename, t) {
 		_, err := syntax.Parse(filename, chunk.Source, 0)
 		switch err := err.(type) {


### PR DESCRIPTION
DataFile claimed to do that before but did not work!
Now has fallback, which reads TEST_SRCDIR (set by Bazel) and builds
Bazely path. For this to work had to remove hardcoded Go paths from
DataFile calls.