### PR TITLE
skylark: reject int() with no arguments

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1935,7 +1935,7 @@ The characters following `%` in each conversion determine which
 argument it uses and how to convert it to a string.
 
 Each `%` character marks the start of a conversion specifier, unless
-it is immediately followed by another `%`, in which cases both
+it is immediately followed by another `%`, in which case both
 characters together denote a literal percent sign.
 
 If the `"%"` is immediately followed by `"(key)"`, the parenthesized

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -439,7 +439,7 @@ non-zero.
 3 / 2                           # 1.5
 111111111 * 111111111           # 12345678987654321
 "0x%x" % (0x1234 & 0xf00f)      # "0x1004"
-int("0xffff")                   # 65535
+int("ffff", 16)                 # 65535, 0xffff
 ```
 
 <b>Implementation note:</b>
@@ -1936,7 +1936,7 @@ argument it uses and how to convert it to a string.
 
 Each `%` character marks the start of a conversion specifier, unless
 it is immediately followed by another `%`, in which cases both
-characters denote a literal percent sign.
+characters together denote a literal percent sign.
 
 If the `"%"` is immediately followed by `"(key)"`, the parenthesized
 substring specifies the key of the `args` dictionary whose
@@ -2892,15 +2892,12 @@ truncating towards zero; it is an error if x is not finite (`NaN`,
 `+Inf`, `-Inf`).
 If x is a `bool`, the result is 0 for `False` or 1 for `True`.
 
-If x is a string, it is interpreted like a string literal;
-an optional base prefix (`0`, `0b`, `0B`, `0x`, `0X`) determines which base to use.
+If x is a string, it is interpreted as a sequence of digits in the
+specified base, decimal by default.
+If `base` is zero, x is interpreted like an integer literal, the base
+being inferred from an optional base prefix such as `0b`, `0o`, or `0x`.
 The string may specify an arbitrarily large integer,
 whereas true integer literals are restricted to 64 bits.
-If a non-zero `base` argument is provided, the string is interpreted
-in that base and no base prefix is permitted; the base argument may
-specified by name.
-
-`int()` with no arguments returns 0.
 
 ### len
 

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -2896,8 +2896,6 @@ If x is a string, it is interpreted as a sequence of digits in the
 specified base, decimal by default.
 If `base` is zero, x is interpreted like an integer literal, the base
 being inferred from an optional base prefix such as `0b`, `0o`, or `0x`.
-The string may specify an arbitrarily large integer,
-whereas true integer literals are restricted to 64 bits.
 
 ### len
 

--- a/library.go
+++ b/library.go
@@ -577,7 +577,7 @@ func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 func int_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value = zero
 	var base Value
-	if err := UnpackArgs("int", args, kwargs, "x?", &x, "base?", &base); err != nil {
+	if err := UnpackArgs("int", args, kwargs, "x", &x, "base?", &base); err != nil {
 		return nil, err
 	}
 

--- a/testdata/int.sky
+++ b/testdata/int.sky
@@ -58,6 +58,7 @@ compound()
 # See float.sky for float-to-int conversions.
 # We follow Python 3 here, but I can't see the method in its madness.
 # int from bool/int/float
+assert.fails(int, 'missing argument')  # int()
 assert.eq(int(False), 0)
 assert.eq(int(True), 1)
 assert.eq(int(3), 3)


### PR DESCRIPTION
...and clarify spec to match Java spec, recently changed to match Java impl.
