### PR TITLE
evaluator: make "x in mapping" ignore errors from Mapping.Get

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1917,6 +1917,7 @@ d = {"one": 1, "two": 2}
 "one" in d                      # True
 "three" in d                    # False
 1 in d                          # False
+[] in d				# False
 
 "nasty" in "dynasty"            # True
 "a" in "banana"                 # True

--- a/eval.go
+++ b/eval.go
@@ -1192,8 +1192,10 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 			return False, nil
 		case Mapping: // e.g. dict
-			_, found, err := y.Get(x)
-			return Bool(found), err
+			// Ignore error from Get as we cannot distinguish true
+			// errors (value cycle, type error) from "key not found".
+			_, found, _ := y.Get(x)
+			return Bool(found), nil
 		case *Set:
 			ok, err := y.Has(x)
 			return Bool(ok), err

--- a/testdata/builtins.sky
+++ b/testdata/builtins.sky
@@ -33,7 +33,7 @@ assert.true(4 not in (1, 2, 3))
 assert.fails(lambda: 3 in "foo", "in.*requires string as left operand")
 assert.true(123 in {123: ""})
 assert.true(456 not in {123:""})
-assert.fails(lambda: [] in {123: ""}, "unhashable")
+assert.true([] not in {123: ""})
 
 # sorted
 assert.eq(sorted([42, 123, 3]), [3, 42, 123])

--- a/value.go
+++ b/value.go
@@ -220,6 +220,9 @@ type Mapping interface {
 	Value
 	// Get returns the value corresponding to the specified key,
 	// or !found if the mapping does not contain the key.
+	//
+	// Get also defines the behavior of "v in mapping".
+	// The 'in' operator reports the 'found' component, ignoring errors.
 	Get(Value) (v Value, found bool, err error)
 }
 


### PR DESCRIPTION
In the result of Get, the evaluator cannot distinguish "no such key"
errors from true errors (value cycle, type error), so we ignore them all.

This matches the Java implementation.
