### PR TITLE
evaluator: replace Function.Syntax method with accessors

### DIFF
--- a/value.go
+++ b/value.go
@@ -475,7 +475,17 @@ func (fn *Function) String() string        { return toString(fn) }
 func (fn *Function) Type() string          { return "function" }
 func (fn *Function) Truth() Bool           { return true }
 
-func (fn *Function) Syntax() *syntax.Function { return fn.syntax }
+// syntax accessors
+//
+// We do not expose the syntax tree; future versions of Function may dispense with it.
+
+func (fn *Function) NumParams() int { return len(fn.syntax.Params) }
+func (fn *Function) Param(i int) (string, syntax.Position) {
+	id := fn.syntax.Locals[i]
+	return id.Name, id.NamePos
+}
+func (fn *Function) HasVarargs() bool { return fn.syntax.HasVarargs }
+func (fn *Function) HasKwargs() bool  { return fn.syntax.HasKwargs }
 
 // A Builtin is a function implemented in Go.
 type Builtin struct {

--- a/value.go
+++ b/value.go
@@ -479,7 +479,8 @@ func (fn *Function) Truth() Bool           { return true }
 //
 // We do not expose the syntax tree; future versions of Function may dispense with it.
 
-func (fn *Function) NumParams() int { return len(fn.syntax.Params) }
+func (fn *Function) Position() syntax.Position { return fn.position }
+func (fn *Function) NumParams() int            { return len(fn.syntax.Params) }
 func (fn *Function) Param(i int) (string, syntax.Position) {
 	id := fn.syntax.Locals[i]
 	return id.Name, id.NamePos


### PR DESCRIPTION
Future versions of Function may not have a syntax tree.
