### PR TITLE
remove PACKAGE_NAME hack

### DIFF
--- a/interp.go
+++ b/interp.go
@@ -526,17 +526,8 @@ loop:
 			name := f.Prog.Names[arg]
 			x := fr.fn.predeclared[name]
 			if x == nil {
-				if name == "PACKAGE_NAME" {
-					// Gross spec, gross hack.
-					// Users should just call package_name() function.
-					if v, ok := fr.fn.predeclared["package_name"].(*Builtin); ok {
-						x, _ = v.fn(thread, v, nil, nil)
-					}
-				}
-				if x == nil {
-					err = fmt.Errorf("internal error: predeclared variable %s is uninitialized", name)
-					break loop
-				}
+				err = fmt.Errorf("internal error: predeclared variable %s is uninitialized", name)
+				break loop
 			}
 			stack[sp] = x
 			sp++

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -348,8 +348,6 @@ func (r *resolver) useGlobal(id *syntax.Ident) binding {
 		id.Index = prev.Index
 	} else if r.isPredeclared(id.Name) {
 		scope = Predeclared // use of pre-declared
-	} else if id.Name == "PACKAGE_NAME" {
-		scope = Predeclared // nasty hack in Skylark spec; will go away (b/34240042).
 	} else if r.isUniversal(id.Name) {
 		scope = Universal // use of universal name
 		if !AllowFloat && id.Name == "float" {


### PR DESCRIPTION
Bazel no longer relies on this special (thread-local) variable.
