### PR TITLE
string.{starts,ends}with: allow tuple-of-string argument, like Python

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3515,7 +3515,7 @@ They are interpreted according to Skylark's [indexing conventions](#indexing).
 ```
 
 The `suffix` argument may be a tuple of strings, in which case the
-function reports whether any one of them was a suffix of S.
+function reports whether any one of them is a suffix of S.
 
 ```python
 'foo.cc'.endswith(('.cc', '.h'))         # True
@@ -3893,7 +3893,7 @@ the final element does not necessarily end with a line terminator.
 ```
 
 The `prefix` argument may be a tuple of strings, in which case the
-function reports whether any one of them was a prefix of S.
+function reports whether any one of them is a prefix of S.
 
 ```python
 'abc'.startswith(('a', 'A'))                  # True

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3508,14 +3508,15 @@ They are interpreted according to Skylark's [indexing conventions](#indexing).
 <a id='string·endswith'></a>
 ### string·endswith
 
-`S.endswith(suffix)` reports whether the string S has the specified suffix.
+`S.endswith(suffix[, start[, end]])` reports whether the string
+`S[start:end]` has the specified suffix.
 
 ```python
 "filename.sky".endswith(".sky")         # True
 ```
 
 The `suffix` argument may be a tuple of strings, in which case the
-function reports whether any one of them is a suffix of S.
+function reports whether any one of them is a suffix.
 
 ```python
 'foo.cc'.endswith(('.cc', '.h'))         # True
@@ -3886,14 +3887,15 @@ the final element does not necessarily end with a line terminator.
 <a id='string·startswith'></a>
 ### string·startswith
 
-`S.startswith(prefix)` reports whether the string S has the specified prefix.
+`S.startswith(prefix[, start[, end]])` reports whether the string
+`S[start:end]` has the specified prefix.
 
 ```python
 "filename.sky".startswith("filename")         # True
 ```
 
 The `prefix` argument may be a tuple of strings, in which case the
-function reports whether any one of them is a prefix of S.
+function reports whether any one of them is a prefix.
 
 ```python
 'abc'.startswith(('a', 'A'))                  # True

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -3514,6 +3514,14 @@ They are interpreted according to Skylark's [indexing conventions](#indexing).
 "filename.sky".endswith(".sky")         # True
 ```
 
+The `suffix` argument may be a tuple of strings, in which case the
+function reports whether any one of them was a suffix of S.
+
+```python
+'foo.cc'.endswith(('.cc', '.h'))         # True
+```
+
+
 <a id='string·find'></a>
 ### string·find
 
@@ -3878,10 +3886,19 @@ the final element does not necessarily end with a line terminator.
 <a id='string·startswith'></a>
 ### string·startswith
 
-`S.startswith(suffix)` reports whether the string S has the specified prefix.
+`S.startswith(prefix)` reports whether the string S has the specified prefix.
 
 ```python
 "filename.sky".startswith("filename")         # True
+```
+
+The `prefix` argument may be a tuple of strings, in which case the
+function reports whether any one of them was a prefix of S.
+
+```python
+'abc'.startswith(('a', 'A'))                  # True
+'ABC'.startswith(('a', 'A'))                  # True
+'def'.startswith(('a', 'A'))                  # False
 ```
 
 <a id='string·strip'></a>

--- a/library.go
+++ b/library.go
@@ -102,8 +102,8 @@ var (
 		"codepoints":     string_iterable, // sic
 		"count":          string_count,
 		"elem_ords":      string_iterable,
-		"elems":          string_iterable, // sic
-		"endswith":       string_endswith,
+		"elems":          string_iterable,   // sic
+		"endswith":       string_startswith, // sic
 		"find":           string_find,
 		"format":         string_format,
 		"index":          string_index,
@@ -1480,16 +1480,6 @@ func string_count(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value
 	return MakeInt(strings.Count(slice, sub)), nil
 }
 
-// https://github.com/google/skylark/blob/master/doc/spec.md#string·endswith
-func string_endswith(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value, error) {
-	recv := string(recv_.(String))
-	var suffix string
-	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &suffix); err != nil {
-		return nil, err
-	}
-	return Bool(strings.HasSuffix(recv, suffix)), nil
-}
-
 // https://github.com/google/skylark/blob/master/doc/spec.md#string·isalnum
 func string_isalnum(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	if err := UnpackPositionalArgs(fnname, args, kwargs, 0); err != nil {
@@ -1855,13 +1845,36 @@ func string_rstrip(fnname string, recv Value, args Tuple, kwargs []Tuple) (Value
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#string·startswith
+// https://github.com/google/skylark/blob/master/doc/spec.md#string·endswith
 func string_startswith(fnname string, recv_ Value, args Tuple, kwargs []Tuple) (Value, error) {
 	recv := string(recv_.(String))
-	var prefix string
-	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &prefix); err != nil {
+	var x Value
+	if err := UnpackPositionalArgs(fnname, args, kwargs, 1, &x); err != nil {
 		return nil, err
 	}
-	return Bool(strings.HasPrefix(recv, prefix)), nil
+
+	f := strings.HasPrefix
+	if fnname[0] == 'e' { // endswith
+		f = strings.HasSuffix
+	}
+
+	switch x := x.(type) {
+	case Tuple:
+		for i, x := range x {
+			prefix, ok := AsString(x)
+			if !ok {
+				return nil, fmt.Errorf("%s: want string, got %s, for element %d",
+					fnname, x.Type(), i)
+			}
+			if f(recv, prefix) {
+				return True, nil
+			}
+		}
+		return False, nil
+	case String:
+		return Bool(f(recv, string(x))), nil
+	}
+	return nil, fmt.Errorf("%s: got %s, want string or tuple of string", fnname, x.Type())
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#string·strip

--- a/testdata/string.sky
+++ b/testdata/string.sky
@@ -279,6 +279,11 @@ assert.true('ABC'.endswith(('c', 'C')))
 assert.true(not 'ABC'.endswith(('b', 'B')))
 assert.fails(lambda: '123'.endswith((1, 2)), 'got int, for element 0')
 assert.fails(lambda: '123'.endswith(['3']), 'got list')
+# start/end
+assert.true('abc'.startswith('bc', 1))
+assert.true(not 'abc'.startswith('b', 999))
+assert.true('abc'.endswith('ab', None, -1))
+assert.true(not 'abc'.endswith('b', None, -999))
 
 # str.replace
 assert.eq("banana".replace("a", "o", 1), "bonana")

--- a/testdata/string.sky
+++ b/testdata/string.sky
@@ -267,6 +267,18 @@ assert.true(not "foo".endswith("x"))
 assert.true("foo".startswith("fo"))
 assert.true(not "foo".startswith("x"))
 assert.fails(lambda: "foo".startswith(1), "got int.*want string")
+#
+assert.true('abc'.startswith(('a', 'A')))
+assert.true('ABC'.startswith(('a', 'A')))
+assert.true(not 'ABC'.startswith(('b', 'B')))
+assert.fails(lambda: '123'.startswith((1, 2)), 'got int, for element 0')
+assert.fails(lambda: '123'.startswith(['3']), 'got list')
+#
+assert.true('abc'.endswith(('c', 'C')))
+assert.true('ABC'.endswith(('c', 'C')))
+assert.true(not 'ABC'.endswith(('b', 'B')))
+assert.fails(lambda: '123'.endswith((1, 2)), 'got int, for element 0')
+assert.fails(lambda: '123'.endswith(['3']), 'got list')
 
 # str.replace
 assert.eq("banana".replace("a", "o", 1), "bonana")


### PR DESCRIPTION
+ spec change, test.

See https://github.com/bazelbuild/bazel/pull/5455.
