### PR TITLE
Builtin: push a Frame on the Thread's stack even when calling Builtins

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -62,11 +62,12 @@ func (thread *Thread) Local(key string) interface{} {
 	return thread.locals[key]
 }
 
-// Caller returns the frame of the innermost enclosing Skylark function.
+// Caller returns the frame of the caller of the current function.
 // It should only be used in built-ins called from Skylark code.
-func (thread *Thread) Caller() *Frame {
-	return thread.frame
-}
+func (thread *Thread) Caller() *Frame { return thread.frame.parent }
+
+// TopFrame returns the topmost stack frame.
+func (thread *Thread) TopFrame() *Frame { return thread.frame }
 
 // A StringDict is a mapping from names to values, and represents
 // an environment such as the global variables of a module.
@@ -107,10 +108,10 @@ func (d StringDict) Has(key string) bool { _, ok := d[key]; return ok }
 // A Frame holds the execution state of a single Skylark function call
 // or module toplevel.
 type Frame struct {
-	parent *Frame          // caller's frame (or nil)
-	posn   syntax.Position // source position of PC, set during error
-	callpc uint32          // PC of position of active call, set during call
-	fn     *Function       // current function (or toplevel)
+	parent   *Frame          // caller's frame (or nil)
+	posn     syntax.Position // source position of PC, set during error
+	callpc   uint32          // PC of position of active call, set during call
+	callable Callable        // current function (or toplevel) or built-in
 }
 
 func (fr *Frame) errorf(posn syntax.Position, format string, args ...interface{}) *EvalError {
@@ -124,11 +125,16 @@ func (fr *Frame) Position() syntax.Position {
 	if fr.posn.IsValid() {
 		return fr.posn // leaf frame only (the error)
 	}
-	return fr.fn.funcode.Position(fr.callpc) // position of active call
+	if fn, ok := fr.callable.(*Function); ok {
+		return fn.funcode.Position(fr.callpc) // position of active call
+	}
+	return syntax.MakePosition(&builtinFilename, 1, 0)
 }
 
-// Function returns the frame's function, or nil for the top-level of a module.
-func (fr *Frame) Function() *Function { return fr.fn }
+var builtinFilename = "<builtin>"
+
+// Function returns the frame's function or built-in.
+func (fr *Frame) Callable() Callable { return fr.callable }
 
 // Parent returns the frame of the enclosing function call, if any.
 func (fr *Frame) Parent() *Frame { return fr.parent }
@@ -157,7 +163,7 @@ func (fr *Frame) WriteBacktrace(out *bytes.Buffer) {
 	print = func(fr *Frame) {
 		if fr != nil {
 			print(fr.parent)
-			fmt.Fprintf(out, "  %s: in %s\n", fr.Position(), fr.fn.Name())
+			fmt.Fprintf(out, "  %s: in %s\n", fr.Position(), fr.Callable().Name())
 		}
 	}
 	print(fr)

--- a/eval.go
+++ b/eval.go
@@ -105,14 +105,18 @@ func (d StringDict) Freeze() {
 // Has reports whether the dictionary contains the specified key.
 func (d StringDict) Has(key string) bool { _, ok := d[key]; return ok }
 
-// A Frame holds the execution state of a single Skylark function call
-// or module toplevel.
+// A Frame records a call to a Skylark function (including module toplevel)
+// or a built-in function or method.
 type Frame struct {
 	parent   *Frame          // caller's frame (or nil)
+	callable Callable        // current function (or toplevel) or built-in
 	posn     syntax.Position // source position of PC, set during error
 	callpc   uint32          // PC of position of active call, set during call
-	callable Callable        // current function (or toplevel) or built-in
 }
+
+// The Frames of a thread are structured as a spaghetti stack, not a
+// slice, so that an EvalError can copy a stack efficiently and immutably.
+// In hindsight using a slice would have led to a more convenient API.
 
 func (fr *Frame) errorf(posn syntax.Position, format string, args ...interface{}) *EvalError {
 	fr.posn = posn

--- a/eval_test.go
+++ b/eval_test.go
@@ -167,7 +167,8 @@ func load(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 	}
 
 	// TODO(adonovan): test load() using this execution path.
-	filename := filepath.Join(filepath.Dir(thread.Caller().Position().Filename()), module)
+	filename := filepath.Join(filepath.Dir(thread.
+		Caller().Position().Filename()), module)
 	return skylark.ExecFile(thread, filename, nil, nil)
 }
 
@@ -322,7 +323,7 @@ f()
 	print := func(thread *skylark.Thread, msg string) {
 		caller := thread.Caller()
 		fmt.Fprintf(buf, "%s: %s: %s\n",
-			caller.Position(), caller.Function().Name(), msg)
+			caller.Position(), caller.Callable().Name(), msg)
 	}
 	thread := &skylark.Thread{Print: print}
 	if _, err := skylark.ExecFile(thread, "foo.go", src, nil); err != nil {
@@ -420,17 +421,18 @@ def i(): return h()
 i()
 `
 	thread := new(skylark.Thread)
-	_, err := skylark.ExecFile(thread, "crash.go", src, nil)
+	_, err := skylark.ExecFile(thread, "crash.sky", src, nil)
 	switch err := err.(type) {
 	case *skylark.EvalError:
 		got := err.Backtrace()
 		// Compiled code currently has no column information.
 		const want = `Traceback (most recent call last):
-  crash.go:6: in <toplevel>
-  crash.go:5: in i
-  crash.go:4: in h
-  crash.go:3: in g
-  crash.go:2: in f
+  crash.sky:6: in <toplevel>
+  crash.sky:5: in i
+  crash.sky:4: in h
+  <builtin>:1: in min
+  crash.sky:3: in g
+  crash.sky:2: in f
 Error: floored division by zero`
 		if got != want {
 			t.Errorf("error was %s, want %s", got, want)

--- a/eval_test.go
+++ b/eval_test.go
@@ -167,8 +167,7 @@ func load(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 	}
 
 	// TODO(adonovan): test load() using this execution path.
-	filename := filepath.Join(filepath.Dir(thread.
-		Caller().Position().Filename()), module)
+	filename := filepath.Join(filepath.Dir(thread.Caller().Position().Filename()), module)
 	return skylark.ExecFile(thread, filename, nil, nil)
 }
 

--- a/value.go
+++ b/value.go
@@ -559,7 +559,12 @@ func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
 func (b *Builtin) Type() string    { return "builtin_function_or_method" }
 func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
-	return b.fn(thread, b, args, kwargs)
+	// TODO(adonovan): opt: we can avoid allocating a Frame unnecessarily if we
+	// do it only when a built-in calls back into Skylark, or when Call fails.
+	thread.frame = &Frame{parent: thread.frame, callable: b}
+	result, err := b.fn(thread, b, args, kwargs)
+	thread.frame = thread.frame.parent
+	return result, err
 }
 func (b *Builtin) Truth() Bool { return true }
 

--- a/value.go
+++ b/value.go
@@ -559,8 +559,6 @@ func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
 func (b *Builtin) Type() string    { return "builtin_function_or_method" }
 func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
-	// TODO(adonovan): opt: we can avoid allocating a Frame unnecessarily if we
-	// do it only when a built-in calls back into Skylark, or when Call fails.
 	thread.frame = &Frame{parent: thread.frame, callable: b}
 	result, err := b.fn(thread, b, args, kwargs)
 	thread.frame = thread.frame.parent


### PR DESCRIPTION
This makes the stack trace more accurate.

Breaking API change: (*Frame).Function is superseded by (*Frame).Callable.