### PR TITLE
api: add Builtin#UnpackArgs as a covenience function

### DIFF
--- a/library.go
+++ b/library.go
@@ -574,10 +574,10 @@ func hash(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#int
-func int_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func int_(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var x Value = zero
 	var base Value
-	if err := UnpackArgs("int", args, kwargs, "x", &x, "base?", &base); err != nil {
+	if err := b.UnpackArgs(args, kwargs, "x", &x, "base?", &base); err != nil {
 		return nil, err
 	}
 
@@ -713,7 +713,7 @@ func minmax(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, err
 		return nil, fmt.Errorf("%s requires at least one positional argument", fn.Name())
 	}
 	var keyFunc Callable
-	if err := UnpackArgs(fn.Name(), nil, kwargs, "key?", &keyFunc); err != nil {
+	if err := fn.UnpackArgs(nil, kwargs, "key?", &keyFunc); err != nil {
 		return nil, err
 	}
 	var op syntax.Token
@@ -1013,11 +1013,11 @@ func set(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 // https://github.com/google/skylark/blob/master/doc/spec.md#sorted
-func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
+func sorted(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) {
 	var iterable Iterable
 	var key Callable
 	var reverse bool
-	if err := UnpackArgs("sorted", args, kwargs,
+	if err := b.UnpackArgs(args, kwargs,
 		"iterable", &iterable,
 		"key?", &key,
 		"reverse?", &reverse,

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -49,9 +49,9 @@ func load(thread *skylark.Thread, module string) (skylark.StringDict, error) {
 }
 
 // gensym is a built-in function that generates a unique symbol.
-func gensym(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func gensym(thread *skylark.Thread, b *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var name string
-	if err := skylark.UnpackArgs("gensym", args, kwargs, "name", &name); err != nil {
+	if err := b.UnpackArgs(args, kwargs, "name", &name); err != nil {
 		return nil, err
 	}
 	return &symbol{name: name}, nil

--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -75,9 +75,9 @@ func LoadAssertModule() (skylark.StringDict, error) {
 
 // catch(f) evaluates f() and returns its evaluation error message
 // if it failed or None if it succeeded.
-func catch(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func catch(thread *skylark.Thread, b *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var fn skylark.Callable
-	if err := skylark.UnpackArgs("catch", args, kwargs, "fn", &fn); err != nil {
+	if err := b.UnpackArgs(args, kwargs, "fn", &fn); err != nil {
 		return nil, err
 	}
 	if _, err := fn.Call(thread, nil, nil); err != nil {
@@ -87,9 +87,9 @@ func catch(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwarg
 }
 
 // matches(pattern, str) reports whether string str matches the regular expression pattern.
-func matches(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func matches(thread *skylark.Thread, b *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var pattern, str string
-	if err := skylark.UnpackArgs("matches", args, kwargs, "pattern", &pattern, "str", &str); err != nil {
+	if err := b.UnpackArgs(args, kwargs, "pattern", &pattern, "str", &str); err != nil {
 		return nil, err
 	}
 	ok, err := regexp.MatchString(pattern, str)

--- a/value.go
+++ b/value.go
@@ -566,6 +566,11 @@ func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error
 }
 func (b *Builtin) Truth() Bool { return true }
 
+// A convenience function for UnpackArgs() with the Builtin Name.
+func (b *Builtin) UnpackArgs(args Tuple, kwargs []Tuple, pairs ...interface{}) error {
+	return UnpackArgs(b.name, args, kwargs, pairs...)
+}
+
 // NewBuiltin returns a new 'builtin_function_or_method' value with the specified name
 // and implementation.  It compares unequal with all other values.
 func NewBuiltin(name string, fn func(thread *Thread, fn *Builtin, args Tuple, kwargs []Tuple) (Value, error)) *Builtin {


### PR DESCRIPTION
This is a simple convenience function to help address a common mistake I've seen a few developers make when they want to add a skylark Builtin.

I also updated a few places in the Skylark codebase to demonstrate places where it comes in handy.

I don't feel strongly about this. Only offering it as a suggestion.