### PR TITLE
Fix parser error for 'not not True' expression

### DIFF
--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -805,8 +805,8 @@ func (p *parser) parsePrimary() Expr {
 			Rparen: rparen,
 		}
 
-	case MINUS, PLUS, TILDE:
-		// unary minus/plus/tilde:
+	case MINUS, PLUS, TILDE, NOT:
+		// unary minus/plus/tilde/not:
 		tok := p.tok
 		pos := p.nextToken()
 		x := p.parsePrimaryWithSuffix()

--- a/testdata/bool.sky
+++ b/testdata/bool.sky
@@ -5,6 +5,7 @@ load("assert.sky", "assert")
 # truth
 assert.true(True)
 assert.true(not False)
+assert.true(not not True)
 
 # bool conversion
 assert.eq([bool(), bool(1), bool(0), bool("hello"), bool("")],


### PR DESCRIPTION
Hello,
I have noticed small error in the Skylark parser:
`>>> not not True`
`... `
`<stdin>:1:8: got not, want primary expression`

But expected behaviour is:
`>>> not not True`
`True`
`>>> not not not True`
`False`

I think 'not not True' should work same way as '--1' -> '1'.

Please consider my tiny fix of this.
