### PR TITLE
Add `HasSetKey` interface for user-implemented dict-ish types.

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -414,7 +414,7 @@ func getIndex(fr *Frame, x, y Value) (Value, error) {
 func setIndex(fr *Frame, x, y, z Value) error {
 	switch x := x.(type) {
 	case *Dict:
-		if err := x.Set(y, z); err != nil {
+		if err := x.SetKey(y, z); err != nil {
 			return err
 		}
 
@@ -508,10 +508,10 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			if y, ok := y.(*Dict); ok {
 				z := new(Dict)
 				for _, item := range x.Items() {
-					z.Set(item[0], item[1])
+					z.SetKey(item[0], item[1])
 				}
 				for _, item := range y.Items() {
-					z.Set(item[0], item[1])
+					z.SetKey(item[0], item[1])
 				}
 				return z, nil
 			}
@@ -1048,7 +1048,7 @@ func setArgs(locals []Value, fn *Function, args Tuple, kwargs []Tuple) error {
 			if kwdict == nil {
 				return fmt.Errorf("function %s got an unexpected keyword argument %s", fn.Name(), k)
 			}
-			kwdict.Set(k, v)
+			kwdict.SetKey(k, v)
 		}
 
 		// default values

--- a/eval.go
+++ b/eval.go
@@ -413,7 +413,7 @@ func getIndex(fr *Frame, x, y Value) (Value, error) {
 // setIndex implements x[y] = z.
 func setIndex(fr *Frame, x, y, z Value) error {
 	switch x := x.(type) {
-	case *Dict:
+	case HasSetKey:
 		if err := x.SetKey(y, z); err != nil {
 			return err
 		}

--- a/interp.go
+++ b/interp.go
@@ -379,7 +379,7 @@ loop:
 			v := stack[sp-1]
 			sp -= 3
 			oldlen := dict.Len()
-			if err2 := dict.Set(k, v); err2 != nil {
+			if err2 := dict.SetKey(k, v); err2 != nil {
 				err = err2
 				break loop
 			}

--- a/library.go
+++ b/library.go
@@ -1278,7 +1278,7 @@ func dict_setdefault(fnname string, recv Value, args Tuple, kwargs []Tuple) (Val
 	} else if ok {
 		return v, nil
 	} else {
-		return dflt, dict.Set(key, dflt)
+		return dflt, dict.SetKey(key, dflt)
 	}
 }
 
@@ -2122,7 +2122,7 @@ func updateDict(dict *Dict, updates Tuple, kwargs []Tuple) error {
 		case *Dict:
 			// Iterate over dict's key/value pairs, not just keys.
 			for _, item := range updates.Items() {
-				if err := dict.Set(item[0], item[1]); err != nil {
+				if err := dict.SetKey(item[0], item[1]); err != nil {
 					return err // dict is frozen
 				}
 			}
@@ -2150,7 +2150,7 @@ func updateDict(dict *Dict, updates Tuple, kwargs []Tuple) error {
 				var k, v Value
 				iter2.Next(&k)
 				iter2.Next(&v)
-				if err := dict.Set(k, v); err != nil {
+				if err := dict.SetKey(k, v); err != nil {
 					return err
 				}
 			}
@@ -2159,7 +2159,7 @@ func updateDict(dict *Dict, updates Tuple, kwargs []Tuple) error {
 
 	// Then add the kwargs.
 	for _, pair := range kwargs {
-		if err := dict.Set(pair[0], pair[1]); err != nil {
+		if err := dict.SetKey(pair[0], pair[1]); err != nil {
 			return err // dict is frozen
 		}
 	}

--- a/value.go
+++ b/value.go
@@ -601,7 +601,7 @@ func (d *Dict) Items() []Tuple                                  { return d.ht.it
 func (d *Dict) Keys() []Value                                   { return d.ht.keys() }
 func (d *Dict) Len() int                                        { return int(d.ht.len) }
 func (d *Dict) Iterate() Iterator                               { return d.ht.iterate() }
-func (d *Dict) Set(k, v Value) error                            { return d.ht.insert(k, v) }
+func (d *Dict) SetKey(k, v Value) error                         { return d.ht.insert(k, v) }
 func (d *Dict) String() string                                  { return toString(d) }
 func (d *Dict) Type() string                                    { return "dict" }
 func (d *Dict) Freeze()                                         { d.ht.freeze() }
@@ -610,6 +610,9 @@ func (d *Dict) Hash() (uint32, error)                           { return 0, fmt.
 
 func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, dictMethods) }
 func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
+
+// Set is an backwards-compatibility alias for SetKey.
+func (d *Dict) Set(k, v Value) error { return d.SetKey(k, v)}
 
 func (x *Dict) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Dict)

--- a/value.go
+++ b/value.go
@@ -28,10 +28,12 @@
 //      Iterable        -- value is iterable using 'for' loops
 //      Sequence        -- value is iterable sequence of known length
 //      Indexable       -- value is sequence with efficient random access
+//      Mapping         -- value maps from keys to values, like a dictionary
 //      HasBinary       -- value defines binary operations such as * and +
 //      HasAttrs        -- value has readable fields or methods x.f
 //      HasSetField     -- value has settable fields x.f
 //      HasSetIndex     -- value supports element update using x[i]=y
+//      HasSetKey       -- value supports map update using x[k]=v
 //
 // Client applications may also define domain-specific functions in Go
 // and make them available to Skylark programs.  Use NewBuiltin to
@@ -231,7 +233,7 @@ type Iterator interface {
 	Done()
 }
 
-// An Mapping is a mapping from keys to values, such as a dictionary.
+// A Mapping is a mapping from keys to values, such as a dictionary.
 type Mapping interface {
 	Value
 	// Get returns the value corresponding to the specified key,
@@ -243,6 +245,14 @@ type Mapping interface {
 }
 
 var _ Mapping = (*Dict)(nil)
+
+// A HasSetKey supports map update using x[k]=v syntax, like a dictionary.
+type HasSetKey interface {
+	Mapping
+	SetKey(k, v Value) error
+}
+
+var _ HasSetKey = (*Dict)(nil)
 
 // A HasBinary value may be used as either operand of these binary operators:
 //     +   -   *   /   %   in   not in   |   &


### PR DESCRIPTION
Currently the only Go type that can support `a[k] = v` syntax is `*Dict`, because `setIndex()` special cases it. This change adds a new interface for setting indexes where the keys are arbitrary values.

The first commit renames `Dict.Set()` to `Dict.SetKey()` (with a compat alias) because I found the method name 'Set' too common to make a nice interface with. I can back out that commit if the Starlark maintainers would prefer to keep the existing name.