### PR TITLE
syntax: add regression test for recent 'not not x' parser bug

### DIFF
--- a/testdata/bool.sky
+++ b/testdata/bool.sky
@@ -6,6 +6,7 @@ load("assert.sky", "assert")
 assert.true(True)
 assert.true(not False)
 assert.true(not not True)
+assert.true(not not 1 >= 1)
 
 # bool conversion
 assert.eq(


### PR DESCRIPTION
This test exercises a case that would not have been fixed
by the first proposed solution (#128), which allowed any number
of not operators to be applied to a primary (such as True)
but did not allow multiple not operators on other expressions
(such as the binary operator 1 >= 1).