### PR TITLE
hash: use Go runtime's hash function

### DIFF
--- a/empty.s
+++ b/empty.s
@@ -1,0 +1,3 @@
+// The presence of this file allows the package to use the
+// "go:linkname" hack to call non-exported functions in the
+// Go runtime, such as hardware-accelerated string hashing.

--- a/hashtable.go
+++ b/hashtable.go
@@ -4,7 +4,10 @@
 
 package skylark
 
-import "fmt"
+import (
+	"fmt"
+	_ "unsafe" // for go:linkname hack
+)
 
 // hashtable is used to represent Skylark dict and set values.
 // It is a hash table whose key/value entries form a doubly-linked list
@@ -331,8 +334,21 @@ func (it *keyIterator) Done() {
 	}
 }
 
-// hashString computes the FNV hash of s.
+// hashString computes the hash of s.
 func hashString(s string) uint32 {
+	if len(s) >= 12 {
+		// Call the Go runtime's optimized hash implementation,
+		// which uses the AESENC instruction on amd64 machines.
+		return uint32(goStringHash(s, 0))
+	}
+	return softHashString(s)
+}
+
+//go:linkname goStringHash runtime.stringHash
+func goStringHash(s string, seed uintptr) uintptr
+
+// softHashString computes the FNV hash of s in software.
+func softHashString(s string) uint32 {
 	var h uint32
 	for i := 0; i < len(s); i++ {
 		h ^= uint32(s[i])

--- a/hashtable_test.go
+++ b/hashtable_test.go
@@ -5,12 +5,32 @@
 package skylark
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 )
 
 func TestHashtable(t *testing.T) {
 	testHashtable(t, make(map[int]bool))
+}
+
+func BenchmarkStringHash(b *testing.B) {
+	for len := 1; len <= 1024; len *= 2 {
+		buf := make([]byte, len)
+		rand.New(rand.NewSource(0)).Read(buf)
+		s := string(buf)
+
+		b.Run(fmt.Sprintf("hard-%d", len), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				hashString(s)
+			}
+		})
+		b.Run(fmt.Sprintf("soft-%d", len), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				softHashString(s)
+			}
+		})
+	}
 }
 
 func BenchmarkHashtable(b *testing.B) {

--- a/value.go
+++ b/value.go
@@ -102,6 +102,8 @@ type Value interface {
 	// Hash returns a function of x such that Equals(x, y) => Hash(x) == Hash(y).
 	// Hash may fail if the value's type is not hashable, or if the value
 	// contains a non-hashable value.
+	//
+	// TODO(adonovan): return a uintptr (a breaking change).
 	Hash() (uint32, error)
 }
 
@@ -622,7 +624,7 @@ func (d *Dict) Attr(name string) (Value, error) { return builtinAttr(d, name, di
 func (d *Dict) AttrNames() []string             { return builtinAttrNames(dictMethods) }
 
 // Set is an backwards-compatibility alias for SetKey.
-func (d *Dict) Set(k, v Value) error { return d.SetKey(k, v)}
+func (d *Dict) Set(k, v Value) error { return d.SetKey(k, v) }
 
 func (x *Dict) CompareSameType(op syntax.Token, y_ Value, depth int) (bool, error) {
 	y := y_.(*Dict)


### PR DESCRIPTION
It uses AESENC instructions on amd64 and for strings of length >=12 starts to rapidly outperform the software implementation. It requires the linkname hack.
```
BenchmarkStringHash/hard-1-12         	300000000	         4.24 ns/op
BenchmarkStringHash/soft-1-12         	1000000000	         2.48 ns/op
BenchmarkStringHash/hard-2-12         	300000000	         4.88 ns/op
BenchmarkStringHash/soft-2-12         	500000000	         3.08 ns/op
BenchmarkStringHash/hard-4-12         	200000000	         6.19 ns/op
BenchmarkStringHash/soft-4-12         	300000000	         4.38 ns/op
BenchmarkStringHash/hard-8-12         	200000000	         7.58 ns/op
BenchmarkStringHash/soft-8-12         	300000000	         5.70 ns/op
BenchmarkStringHash/hard-16-12        	200000000	         8.49 ns/op
BenchmarkStringHash/soft-16-12        	100000000	        10.8 ns/op
BenchmarkStringHash/hard-32-12        	200000000	         8.68 ns/op
BenchmarkStringHash/soft-32-12        	50000000	        24.8 ns/op
BenchmarkStringHash/hard-64-12        	100000000	        10.5 ns/op
BenchmarkStringHash/soft-64-12        	30000000	        56.6 ns/op
BenchmarkStringHash/hard-128-12       	100000000	        15.3 ns/op
BenchmarkStringHash/soft-128-12       	10000000	       125 ns/op
BenchmarkStringHash/hard-256-12       	100000000	        17.7 ns/op
BenchmarkStringHash/soft-256-12       	 5000000	       267 ns/op
BenchmarkStringHash/hard-512-12       	50000000	        26.7 ns/op
BenchmarkStringHash/soft-512-12       	 3000000	       551 ns/op
BenchmarkStringHash/hard-1024-12      	30000000	        45.1 ns/op
BenchmarkStringHash/soft-1024-12      	 1000000	      1143 ns/op
```