### PR TITLE
skylark: rename Callable.Call to CallInternal

### DIFF
--- a/interp.go
+++ b/interp.go
@@ -18,13 +18,13 @@ const vmdebug = false // TODO(adonovan): use a bitfield of specific kinds of err
 //   in the thread, and slicing it.
 // - opt: record MaxIterStack during compilation and preallocate the stack.
 
-func (fn *Function) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
+func (fn *Function) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
 	if debug {
 		fmt.Printf("call of %s %v %v\n", fn.Name(), args, kwargs)
 	}
 
 	// detect recursion
-	for fr := thread.frame; fr != nil; fr = fr.parent {
+	for fr := thread.frame.parent; fr != nil; fr = fr.parent {
 		// We look for the same function code,
 		// not function value, otherwise the user could
 		// defeat the check by writing the Y combinator.
@@ -33,10 +33,7 @@ func (fn *Function) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, err
 		}
 	}
 
-	thread.frame = &Frame{parent: thread.frame, callable: fn}
-	result, err := call(thread, args, kwargs)
-	thread.frame = thread.frame.parent
-	return result, err
+	return call(thread, args, kwargs)
 }
 
 func call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -70,7 +70,7 @@ func (sym *symbol) Freeze()               {} // immutable
 func (sym *symbol) Truth() skylark.Bool   { return skylark.True }
 func (sym *symbol) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", sym.Type()) }
 
-func (sym *symbol) Call(thread *skylark.Thread, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func (sym *symbol) CallInternal(thread *skylark.Thread, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	if len(args) > 0 {
 		return nil, fmt.Errorf("%s: unexpected positional arguments", sym)
 	}

--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -80,7 +80,7 @@ func catch(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwarg
 	if err := skylark.UnpackArgs("catch", args, kwargs, "fn", &fn); err != nil {
 		return nil, err
 	}
-	if _, err := fn.Call(thread, nil, nil); err != nil {
+	if _, err := skylark.Call(thread, fn, nil, nil); err != nil {
 		return skylark.String(err.Error()), nil
 	}
 	return skylark.None, nil

--- a/value.go
+++ b/value.go
@@ -144,10 +144,12 @@ var (
 )
 
 // A Callable value f may be the operand of a function call, f(x).
+//
+// Clients should use the Call function, never the CallInternal method.
 type Callable interface {
 	Value
 	Name() string
-	Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error)
+	CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 var (
@@ -577,11 +579,8 @@ func (b *Builtin) Hash() (uint32, error) {
 func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
 func (b *Builtin) Type() string    { return "builtin_function_or_method" }
-func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
-	thread.frame = &Frame{parent: thread.frame, callable: b}
-	result, err := b.fn(thread, b, args, kwargs)
-	thread.frame = thread.frame.parent
-	return result, err
+func (b *Builtin) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
+	return b.fn(thread, b, args, kwargs)
 }
 func (b *Builtin) Truth() Bool { return true }
 


### PR DESCRIPTION
Clients must now always call skylark.Call(thread, c, args, kwargs),
never c.CallInternal(thread, args, kwargs).

A Skylark thread now accurately reports the stack of Skylark callables,
whether Skylark functions, interpreter built-ins, or application-defined
builtins.  The latter category was necessarily missing before.

This is a breaking API change (sorry), but it should be easy to fix.