### PR TITLE
skylark: fix a crash in call f(*args, named=value)

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -298,6 +298,8 @@ def f(a, b=42, *args, **kwargs):
 		{`f(0, b=1)`, `(0, 1, (), {})`},
 		{`f(0, a=1)`, `function f got multiple values for keyword argument "a"`},
 		{`f(0, b=1, c=2)`, `(0, 1, (), {"c": 2})`},
+		{`f(0, 1, x=2, *[3, 4], y=5, **dict(z=6))`, // github.com/google/skylark/issues/135
+			`(0, 1, (3, 4), {"x": 2, "y": 5, "z": 6})`},
 	} {
 		var got string
 		if v, err := skylark.Eval(thread, "<expr>", test.src, globals); err != nil {

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -1507,6 +1507,10 @@ func (fcomp *fcomp) args(call *syntax.CallExpr) (op Opcode, arg uint32) {
 	var varargs, kwargs syntax.Expr
 	for _, arg := range call.Args {
 		if binary, ok := arg.(*syntax.BinaryExpr); ok && binary.Op == syntax.EQ {
+
+			// named argument (name, value)
+			fcomp.string(binary.X.(*syntax.Ident).Name)
+			fcomp.expr(binary.Y)
 			n++
 			continue
 		}
@@ -1521,21 +1525,33 @@ func (fcomp *fcomp) args(call *syntax.CallExpr) (op Opcode, arg uint32) {
 				continue
 			}
 		}
+
+		// positional argument
+		fcomp.expr(arg)
 		p++
 	}
 
-	// positional arguments
-	for _, elem := range call.Args[:p] {
-		fcomp.expr(elem)
-	}
-
-	// named argument pairs (name, value, ..., name, value)
-	named := call.Args[p : p+n]
-	for _, arg := range named {
-		binary := arg.(*syntax.BinaryExpr)
-		fcomp.string(binary.X.(*syntax.Ident).Name)
-		fcomp.expr(binary.Y)
-	}
+	// Python2, Python3, and Skylark-in-Java all permit named arguments
+	// to appear both before and after a *args argument:
+	//   f(1, 2, x=3, *[4], y=5, **dict(z=6))
+	//
+	// However all three implement different argument evaluation orders:
+	//  Python2: 1 2 3 5 4 6 (*args and **kwargs evaluated last)
+	//  Python3: 1 2 4 3 5 6 (positional args evaluated before named args)
+	//  Skylark-in-Java: 1 2 3 4 5 6 (lexical order)
+	//
+	// The Skylark-in-Java semantics are clean but hostile to a
+	// compiler-based implementation because they require that the
+	// compiler emit code for positional, named, *args, more named,
+	// and *kwargs arguments and provide the callee with a map of
+	// the terrain.
+	//
+	// For now we implement the Python2 semantics, but
+	// the spec needs to clarify the correct approach.
+	// Perhaps it would be best if we statically rejected
+	// named arguments after *args (e.g. y=5) so that the
+	// Python2 implementation strategy matches lexical order.
+	// Discussion in Google issue b/118052120.
 
 	// *args
 	if varargs != nil {

--- a/interp.go
+++ b/interp.go
@@ -18,13 +18,13 @@ const vmdebug = false // TODO(adonovan): use a bitfield of specific kinds of err
 //   in the thread, and slicing it.
 // - opt: record MaxIterStack during compilation and preallocate the stack.
 
-func (fn *Function) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
+func (fn *Function) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
 	if debug {
 		fmt.Printf("call of %s %v %v\n", fn.Name(), args, kwargs)
 	}
 
 	// detect recursion
-	for fr := thread.frame; fr != nil; fr = fr.parent {
+	for fr := thread.frame.parent; fr != nil; fr = fr.parent {
 		// We look for the same function code,
 		// not function value, otherwise the user could
 		// defeat the check by writing the Y combinator.
@@ -33,10 +33,7 @@ func (fn *Function) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, err
 		}
 	}
 
-	thread.frame = &Frame{parent: thread.frame, callable: fn}
-	result, err := call(thread, args, kwargs)
-	thread.frame = thread.frame.parent
-	return result, err
+	return call(thread, args, kwargs)
 }
 
 func call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {

--- a/skylarkstruct/struct_test.go
+++ b/skylarkstruct/struct_test.go
@@ -70,7 +70,7 @@ func (sym *symbol) Freeze()               {} // immutable
 func (sym *symbol) Truth() skylark.Bool   { return skylark.True }
 func (sym *symbol) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", sym.Type()) }
 
-func (sym *symbol) Call(thread *skylark.Thread, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+func (sym *symbol) CallInternal(thread *skylark.Thread, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	if len(args) > 0 {
 		return nil, fmt.Errorf("%s: unexpected positional arguments", sym)
 	}

--- a/skylarktest/skylarktest.go
+++ b/skylarktest/skylarktest.go
@@ -80,7 +80,7 @@ func catch(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwarg
 	if err := skylark.UnpackArgs("catch", args, kwargs, "fn", &fn); err != nil {
 		return nil, err
 	}
-	if _, err := fn.Call(thread, nil, nil); err != nil {
+	if _, err := skylark.Call(thread, fn, nil, nil); err != nil {
 		return skylark.String(err.Error()), nil
 	}
 	return skylark.None, nil

--- a/testdata/function.sky
+++ b/testdata/function.sky
@@ -184,3 +184,24 @@ def f(a, b, x, y):
   return a+b+x+y
 
 assert.eq(f(*("a", "b"), **dict(y="y", x="x")) + ".", 'abxy.')
+---
+# Order of evaluation of function arguments.
+# Regression test for github.com/google/skylark/issues/135.
+load("assert.sky", "assert")
+
+r = []
+
+def id(x):
+       r.append(x)
+       return x
+
+def f(*args, **kwargs):
+  return (args, kwargs)
+
+y = f(id(1), id(2), x=id(3), *[id(4)], y=id(5), **dict(z=id(6)))
+assert.eq(y, ((1, 2, 4), dict(x=3, y=5, z=6)))
+
+# This matches Python2, but not Skylark-in-Java:
+# *args and *kwargs are evaluated last.
+# See Google issue b/118052120 for pending spec change.
+assert.eq(r, [1, 2, 3, 5, 4, 6])

--- a/value.go
+++ b/value.go
@@ -144,10 +144,12 @@ var (
 )
 
 // A Callable value f may be the operand of a function call, f(x).
+//
+// Clients should use the Call function, never the CallInternal method.
 type Callable interface {
 	Value
 	Name() string
-	Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error)
+	CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error)
 }
 
 var (
@@ -577,11 +579,8 @@ func (b *Builtin) Hash() (uint32, error) {
 func (b *Builtin) Receiver() Value { return b.recv }
 func (b *Builtin) String() string  { return toString(b) }
 func (b *Builtin) Type() string    { return "builtin_function_or_method" }
-func (b *Builtin) Call(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
-	thread.frame = &Frame{parent: thread.frame, callable: b}
-	result, err := b.fn(thread, b, args, kwargs)
-	thread.frame = thread.frame.parent
-	return result, err
+func (b *Builtin) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Value, error) {
+	return b.fn(thread, b, args, kwargs)
 }
 func (b *Builtin) Truth() Bool { return true }
 


### PR DESCRIPTION
Fixes #135
