### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -208,7 +208,7 @@ func (prog *Program) Load(i int) (string, syntax.Position) {
 	return id.Name, id.Pos
 }
 
-// WriteTo writes the compiled module to the specified output stream.
+// Write writes the compiled module to the specified output stream.
 func (prog *Program) Write(out io.Writer) error { return prog.compiled.Write(out) }
 
 // ExecFile parses, resolves, and executes a Skylark file in the


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?